### PR TITLE
Give every action its own symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ Clicking the ribbon icon opens a menu with options to:
 - Remove the current line's header, or place it as a sibling or child of the
   header above.
 
+### On Mobile
+
+Obsidian's mobile toolbar shows commands as icons with no names, so every
+command this plugin registers carries its own symbol and no two are alike:
+
+| Symbol family      | Scope                            |
+| ------------------ | -------------------------------- |
+| Solid arrow        | the dialog — you say how far     |
+| Page with +/−      | the whole note                   |
+| Box with +/−       | the selection                    |
+| Bare chevron       | the current line                 |
+| A struck through   | remove the header                |
+| Equals sign        | sibling of the header above      |
+| Arrow turning in   | child of the header above        |
+
+Up increases and down decreases throughout, so there are two things to learn
+rather than eleven.
+
+To add one: Settings → Toolbar, then pick the commands you want. The ribbon
+menu shows the same symbols beside their names, which is the quickest way to
+learn which is which.
+
 ### Modal Input
 
 When using the "Increase header level..." or "Decrease header level..." commands, a dialog will prompt you to:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ Breaking one fails the build.
 ```
 main.ts                              root
 ├── commands/commandSurfaces.ts      door — ribbon icon + palette entries
+│   ├── commands/icons.ts            one symbol per action
 │   └── commands/adjustmentCommands.ts
 │       ├── commands/activeEditor.ts             which editor a command acts on
 │       ├── editor/headingAdjustmentService.ts   door — the only place effects happen
@@ -170,6 +171,13 @@ than leaving each caller to work them out.
   an effect: one undoable transaction and one `Notice`.
 - **`settings/`** is the policy — defaults, how a stored value is read back,
   how a default is chosen — with the dialog that edits it behind the door.
+- **`commands/`** owns how an action is offered, which on mobile means its
+  symbol as much as its name: the toolbar there shows the icon and nothing
+  else, so two actions wearing one glyph are two actions a user cannot tell
+  apart. `icons.ts` holds the symbol next to nothing but itself, and both the
+  palette entry and the ribbon item read it, so the two cannot drift. The
+  ribbon menu is also where every symbol appears at once, which is what makes
+  a missing one visible.
 - **`commands/`** never imports `settings/`. `CommandContext` asks for
   `defaultLevel(operation)` rather than for the settings object, because the
   plugin is what owns the settings.

--- a/src/commands/commandSurfaces.ts
+++ b/src/commands/commandSurfaces.ts
@@ -2,6 +2,7 @@ import type { Editor, Plugin } from 'obsidian';
 import type { AdjustmentOperation, LinePlacement } from '../contracts';
 import type { CommandContext } from './adjustmentCommands';
 import { Menu } from 'obsidian';
+import { PLACEMENT_ICON, SHIFT_ICON } from './icons';
 import {
   adjustActiveDocument,
   adjustActiveSelection,
@@ -20,6 +21,11 @@ import {
  * placement has no direction, so there is nothing to pair it with. The ribbon
  * menu is written out, because its order and its separators are the thing being
  * designed.
+ *
+ * Every entry takes its symbol from `icons.ts` rather than naming one, so a
+ * command and the menu item that runs it cannot come to wear different glyphs.
+ * The palette shows names and does not need them; the mobile toolbar shows
+ * nothing else.
  */
 
 const OPERATIONS: AdjustmentOperation[] = ['increase', 'decrease'];
@@ -29,20 +35,14 @@ const OPERATIONS: AdjustmentOperation[] = ['increase', 'decrease'];
  * names the line because it stands alone in a search, the menu entry does not
  * because the group it sits in already said so.
  */
-const PLACEMENTS: Array<[LinePlacement, string, string, string]> = [
-  ['plain', 'Remove header from current line', 'Remove header', 'x-square'],
+const PLACEMENTS: Array<[LinePlacement, string, string]> = [
+  ['plain', 'Remove header from current line', 'Remove header'],
   [
     'sibling',
     'Make current line a sibling of the header above',
     'Sibling of the header above',
-    'equal',
   ],
-  [
-    'child',
-    'Make current line a child of the header above',
-    'Child of the header above',
-    'corner-down-right',
-  ],
+  ['child', 'Make current line a child of the header above', 'Child of the header above'],
 ];
 
 export function registerCommandSurfaces(
@@ -61,6 +61,7 @@ export function registerCommandSurfaces(
     plugin.addCommand({
       id: `header-current-line-${placement}`,
       name,
+      icon: PLACEMENT_ICON[placement],
       callback: () => placeCurrentLine(context, placement),
     });
   }
@@ -81,24 +82,28 @@ function registerCommandsFor(
   plugin.addCommand({
     id: `${operation}-header-level`,
     name: `${verb(operation)} header level...`,
+    icon: SHIFT_ICON.prompt[operation],
     callback: () => promptForAdjustment(context, operation),
   });
 
   plugin.addCommand({
     id: `${operation}-header-level-default`,
     name: `${verb(operation)} header level by ${levels} (entire document)`,
+    icon: SHIFT_ICON.document[operation],
     callback: () => adjustActiveDocument(context, operation),
   });
 
   plugin.addCommand({
     id: `${operation}-header-level-current-line`,
     name: `${verb(operation)} header level of current line by ${levels}`,
+    icon: SHIFT_ICON.line[operation],
     callback: () => adjustCurrentLine(context, operation),
   });
 
   plugin.addCommand({
     id: `${operation}-header-level-selection-default`,
     name: `${verb(operation)} header level in selection by ${levels}`,
+    icon: SHIFT_ICON.selection[operation],
     editorCheckCallback: (checking: boolean, editor: Editor) => {
       if (!editor.somethingSelected()) {
         return false;
@@ -116,40 +121,46 @@ function buildRibbonMenu(context: CommandContext): Menu {
   const increaseBy = context.defaultLevel('increase');
   const decreaseBy = context.defaultLevel('decrease');
 
-  addMenuItem(menu, 'Increase level...', 'plus-square', () =>
+  addMenuItem(menu, 'Increase level...', SHIFT_ICON.prompt.increase, () =>
     promptForAdjustment(context, 'increase')
   );
-  addMenuItem(menu, 'Decrease level...', 'minus-square', () =>
+  addMenuItem(menu, 'Decrease level...', SHIFT_ICON.prompt.decrease, () =>
     promptForAdjustment(context, 'decrease')
   );
   menu.addSeparator();
 
-  addMenuItem(menu, 'Increase level by 1 (Document)', 'chevron-up', () =>
+  addMenuItem(menu, 'Increase level by 1 (Document)', SHIFT_ICON.document.increase, () =>
     adjustActiveDocument(context, 'increase', 1)
   );
-  addMenuItem(menu, 'Decrease level by 1 (Document)', 'chevron-down', () =>
+  addMenuItem(menu, 'Decrease level by 1 (Document)', SHIFT_ICON.document.decrease, () =>
     adjustActiveDocument(context, 'decrease', 1)
   );
   menu.addSeparator();
 
-  addMenuItem(menu, `Increase level by (+${increaseBy}) (Selection)`, 'plus-square', () =>
-    adjustActiveSelection(context, 'increase')
+  addMenuItem(
+    menu,
+    `Increase level by (+${increaseBy}) (Selection)`,
+    SHIFT_ICON.selection.increase,
+    () => adjustActiveSelection(context, 'increase')
   );
-  addMenuItem(menu, `Decrease level by (-${decreaseBy}) (Selection)`, 'minus-square', () =>
-    adjustActiveSelection(context, 'decrease')
+  addMenuItem(
+    menu,
+    `Decrease level by (-${decreaseBy}) (Selection)`,
+    SHIFT_ICON.selection.decrease,
+    () => adjustActiveSelection(context, 'decrease')
   );
   menu.addSeparator();
 
-  addMenuItem(menu, `Increase level by (+${increaseBy}) (Current line)`, 'plus-square', () =>
+  addMenuItem(menu, `Increase level by (+${increaseBy}) (Current line)`, SHIFT_ICON.line.increase, () =>
     adjustCurrentLine(context, 'increase')
   );
-  addMenuItem(menu, `Decrease level by (-${decreaseBy}) (Current line)`, 'minus-square', () =>
+  addMenuItem(menu, `Decrease level by (-${decreaseBy}) (Current line)`, SHIFT_ICON.line.decrease, () =>
     adjustCurrentLine(context, 'decrease')
   );
   menu.addSeparator();
 
-  for (const [placement, , label, icon] of PLACEMENTS) {
-    addMenuItem(menu, `${label} (Current line)`, icon, () =>
+  for (const [placement, , label] of PLACEMENTS) {
+    addMenuItem(menu, `${label} (Current line)`, PLACEMENT_ICON[placement], () =>
       placeCurrentLine(context, placement)
     );
   }

--- a/src/commands/icons.ts
+++ b/src/commands/icons.ts
@@ -1,0 +1,46 @@
+import type { AdjustmentOperation, LinePlacement } from '../contracts';
+
+/**
+ * The symbol each action is known by.
+ *
+ * On the mobile toolbar a symbol is the whole of what a user has to go on:
+ * there is no room for a name, so two actions sharing a glyph are two actions
+ * that cannot be told apart. That makes the symbol part of what an action *is*,
+ * which is why it is written down once here and read by every surface rather
+ * than chosen again at each one.
+ *
+ * Direction is carried by the family — an up glyph increases, its down twin
+ * decreases — and scope by which family it is, so a user learns two things
+ * rather than eleven. `tests/commands/icons.test.ts` holds them apart.
+ */
+
+/** What a shift applies to. The four scopes, as the surfaces name them. */
+export type ShiftScope = 'prompt' | 'document' | 'selection' | 'line';
+
+/**
+ * A symbol per scope and direction.
+ *
+ * The solid arrows are the dialog, which is the one that asks how far; the file
+ * is the whole note; the box is the selected block; the bare chevron is a single
+ * line taking a single step. Chevron against solid arrow is the widest gap the
+ * set has, which is what the two most likely to be pinned together want.
+ */
+export const SHIFT_ICON: Record<ShiftScope, Record<AdjustmentOperation, string>> = {
+  prompt: { increase: 'arrow-big-up', decrease: 'arrow-big-down' },
+  document: { increase: 'file-plus', decrease: 'file-minus' },
+  selection: { increase: 'plus-square', decrease: 'minus-square' },
+  line: { increase: 'chevron-up', decrease: 'chevron-down' },
+};
+
+/**
+ * A symbol per placement.
+ *
+ * These name a level rather than a direction, so they say what the line becomes
+ * instead of which way it moves: the markup stripped off, a level held equal, a
+ * step in and down.
+ */
+export const PLACEMENT_ICON: Record<LinePlacement, string> = {
+  plain: 'remove-formatting',
+  sibling: 'equal',
+  child: 'corner-down-right',
+};

--- a/tests/commands/icons.test.ts
+++ b/tests/commands/icons.test.ts
@@ -1,0 +1,77 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { registerCommandSurfaces } from '../../src/commands/commandSurfaces';
+import { PLACEMENT_ICON, SHIFT_ICON } from '../../src/commands/icons';
+
+/**
+ * That every action is reachable by symbol alone.
+ *
+ * The command palette shows names, so nothing there would notice a missing or
+ * repeated icon. The mobile toolbar shows only the icon, which makes this the
+ * one place the requirement can be checked at all.
+ */
+
+interface RegisteredCommand {
+  id: string;
+  name: string;
+  icon?: string;
+}
+
+/** The commands the plugin registers, as a fake Obsidian records them. */
+function registeredCommands(): RegisteredCommand[] {
+  const commands: RegisteredCommand[] = [];
+  const plugin = {
+    addRibbonIcon: () => null,
+    addCommand: (command: RegisteredCommand) => commands.push(command),
+  };
+  const context = { app: {}, defaultLevel: () => 1, conversion: () => ({}) };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerCommandSurfaces(plugin as any, context as any);
+
+  return commands;
+}
+
+describe('every action carries a symbol', () => {
+  const commands = registeredCommands();
+
+  test('there is a command for each scope in each direction, plus the placements', () => {
+    assert.equal(commands.length, 11);
+  });
+
+  for (const command of commands) {
+    test(`${command.id} has one`, () => {
+      assert.ok(command.icon, `${command.id} would reach the toolbar unlabelled`);
+    });
+  }
+});
+
+describe('no two actions wear the same symbol', () => {
+  test('across every command the plugin registers', () => {
+    const commands = registeredCommands();
+    const byIcon = new Map<string, string[]>();
+
+    for (const command of commands) {
+      const icon = command.icon ?? '(none)';
+      byIcon.set(icon, [...(byIcon.get(icon) ?? []), command.id]);
+    }
+
+    const shared = [...byIcon.entries()].filter(([, ids]) => ids.length > 1);
+
+    assert.deepEqual(
+      shared,
+      [],
+      shared.map(([icon, ids]) => `${icon} is worn by ${ids.join(' and ')}`).join('; ')
+    );
+  });
+
+  test('the tables themselves hold every symbol apart', () => {
+    const icons = [
+      ...Object.values(SHIFT_ICON).flatMap((pair) => Object.values(pair)),
+      ...Object.values(PLACEMENT_ICON),
+    ];
+
+    assert.equal(new Set(icons).size, icons.length);
+  });
+});


### PR DESCRIPTION
Obsidian's mobile toolbar shows a command as an icon and nothing else, so a symbol is the whole of what a user has there to tell two actions apart. None of the eleven commands declared one, which left them all wearing the same fallback glyph on the one surface where the name is not shown.

The icon the toolbar reads is the command's own `icon`, not the ribbon's. The ribbon icon is the single sidebar button, which for this plugin opens a menu — so nothing done to it could have reached the toolbar at all.

## The symbols

| Command | Symbol |
| --- | --- |
| Increase / Decrease header level… | `arrow-big-up` / `arrow-big-down` |
| … by N (entire document) | `file-plus` / `file-minus` |
| … in selection by N | `plus-square` / `minus-square` |
| … of current line by N | `chevron-up` / `chevron-down` |
| Remove header from current line | `remove-formatting` |
| Make current line a sibling of the header above | `equal` |
| Make current line a child of the header above | `corner-down-right` |

Direction is carried by the family — an up glyph increases, its down twin decreases — and scope by which family it is, so there are two things to learn rather than eleven. The dialog and the current line are the two most likely to be pinned side by side, so they take the widest gap the set has, a solid arrow against a bare chevron, rather than two chevrons differing by one stroke.

## Also fixed

The ribbon menu had been wearing `plus-square` for three separate actions: the dialog, the selection and the current line. Symbols now live once in `commands/icons.ts` and both the command and the menu item that runs it read the same constant, so the two cannot come to disagree.

That also puts every symbol in one place on screen. The ribbon menu is now the quickest way to check the whole set, which matters because Obsidian renders an unknown icon name as a blank rather than as an error.

## Worth a look before merging

The icon names cannot be checked against Obsidian's bundled Lucide set from a build. Four are already proven in this repo (`chevron-up`/`chevron-down`, `plus-square`/`minus-square`); the rest are long-standing Lucide names, with `remove-formatting` the one most worth confirming. Opening the ribbon menu shows all ten at once.

## Tests

`tests/commands/icons.test.ts` registers the real surfaces against a fake plugin rather than reading the tables, so a command added later without a symbol fails the build instead of turning up unlabelled on someone's phone. It asserts every command carries an icon and that no two share one.

443 tests pass; lint and `tsc` clean.