### PR TITLE
Toggle a heading on and off the current line

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,10 @@ it. There are three: **sibling**, **child**, and **plain**. A placement reads th
 **enclosing heading** and never reads how deep the line is written now, which is
 what separates it from an **increase** or a **decrease**.
 
+**Root**:
+A placement putting the line at `#`, the top of the note, answering to nothing
+above it. Reachable only by pointing a **toggle** at it.
+
 **Sibling**:
 A placement putting the line at the **enclosing heading**'s own level, so the two
 become siblings in the outline.
@@ -58,6 +62,17 @@ it becomes the first heading inside that section.
 **Plain**:
 A placement putting the line at **level zero** — no heading at all. This is how
 a heading is taken off outright, whatever level it was written at.
+
+**Toggle target**:
+Which of **root**, **sibling** or **child** a **toggle** is pointed at. The user
+sets it; it ships as **sibling**.
+
+**Toggle**:
+A placement that is its **toggle target** unless the line is already sitting
+there, in which case it is **plain**. The only placement that reads the level
+the line is written at, and the only one that is two answers wearing one name —
+which is what lets a user who has one key or one toolbar slot both make a
+section and unmake it.
 
 **Heading ceiling**:
 The deepest level a heading may occupy before it converts, which the user sets.
@@ -103,6 +118,11 @@ out. Only **decrease** does this, and only when explicitly enabled.
   distance reads the level the line is written at
 - **Sibling** and **child** both land on `#` when there is no **enclosing
   heading**, because the note they sit in is **level zero**
+- A **toggle** pressed twice returns the line it started from. A heading at any
+  other level is levelled to the **toggle target** first rather than removed, so
+  the second press is what takes it off
+- A **toggle** takes off only the level it puts on: pointed at **child**, it
+  leaves a **sibling** heading standing and moves it instead
 - A line's **list marker** and its **heading level** are the same slot: writing
   a heading onto a list item replaces the marker rather than following it, since
   a line cannot be a bullet and a heading at once

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ say.
 - **Increase heading level of current line by N** / **Decrease heading level of
   current line by N**: Shifts the line the cursor is on, and nothing else. See
   [The current line](#the-current-line) below.
+- **Toggle heading on current line**: Puts a heading on the current line at the
+  level of the heading above, or takes it off again if it is already there. One
+  binding for both halves — see [Toggling](#toggling) below.
 - **Remove heading from current line**: Turns the current line back into plain
   text, whatever level it was at.
 - **Make current line a sibling of the heading above**: Sets the current line to
@@ -85,7 +88,10 @@ command this plugin registers carries its own symbol and no two are alike:
 | Arrow turning in | child of the heading above   |
 
 Up increases and down decreases throughout, so there are two things to learn
-rather than eleven.
+rather than twelve.
+
+If you only have one slot, spend it on the hash: "Toggle heading on current
+line" both makes a section and unmakes it.
 
 To add one: Settings → Toolbar, then pick the commands you want. The ribbon
 menu shows the same symbols beside their names, which is the quickest way to
@@ -147,6 +153,34 @@ If there is no heading above the line, both "sibling" and "child" produce an `#`
 — the note itself is what encloses the line. A heading inside a code fence does
 not count as the heading above, and a line inside one is left alone.
 
+#### Toggling
+
+"Toggle heading on current line" is the sibling placement and the removal in one
+command, which is what you want if you have a single hotkey or a single free
+slot on the mobile toolbar to spend:
+
+```markdown
+# Guide
+## Setup
+some prose        ← cursor here
+```
+
+| Toggle set to                     | Once             | Twice        |
+| --------------------------------- | ---------------- | ------------ |
+| Same level as the heading above    | `## some prose`  | `some prose` |
+| One level below the heading above  | `### some prose` | `some prose` |
+| Top level                          | `# some prose`   | `some prose` |
+
+Which of the three it uses is yours to set, under **Toggle puts the heading at**
+in the settings. It ships as "same level as the heading above".
+
+A heading already at some *other* level is moved to the one you chose rather
+than removed, so the second press is what takes it off. That keeps two presses
+enough to reach plain text from anywhere, and keeps a press from ever destroying
+a level you would have to retype. It also means the toggle only takes off the
+level it puts on: set to "one below", it will move a sibling heading rather than
+remove it.
+
 #### Lines that are already bullets
 
 A line cannot be a bullet and a heading at once, so writing a heading onto a list
@@ -170,6 +204,9 @@ Access the plugin settings from the Obsidian Settings under the "Heading Adjuste
 
 - **Default increase level**: The default number of levels to increase headings by.
 - **Default decrease level**: The default number of levels to decrease headings by.
+- **Toggle puts the heading at**: Which level "Toggle heading on current line"
+  writes, and so which level it takes back off — the top level (`#`), the same
+  level as the heading above, or one below it. Defaults to the same level.
 - **Deepest heading level**: The level headings stop at. Anything an increase
   would push past it becomes a bulleted list item instead, and a bullet
   converted back returns to this level. Only has an effect with a conversion

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,8 @@ main.ts                              root
 │           └── ui/levelInputForm.ts
 │               └── ui/submissionValidation.ts
 └── settings/settings.ts             door
-    └── settings/settingsTab.ts
+    └── settings/settingsTab.ts      how Obsidian is handed them
+        └── settings/controls.ts     what the settings are
 
 contracts.ts                         shared vocabulary — outside the tree
 ```
@@ -171,6 +172,12 @@ than leaving each caller to work them out.
   an effect: one undoable transaction and one `Notice`.
 - **`settings/`** is the policy — defaults, how a stored value is read back,
   how a default is chosen — with the dialog that edits it behind the door.
+  `controls.ts` is the list of settings there are; `settingsTab.ts` is the two
+  ways Obsidian gets them, described from 1.13 and drawn by hand before that.
+  Both paths read the one list, so neither can describe a setting the other
+  does not have. A stored value is whatever the file held, so a control that
+  admits only some strings — the toggle target does — checks the value against
+  the very options the user chose from rather than a second list of its own.
 - **`commands/`** owns how an action is offered, which on mobile means its
   symbol as much as its name: the toolbar there shows the icon and nothing
   else, so two actions wearing one glyph are two actions a user cannot tell

--- a/src/commands/adjustmentCommands.ts
+++ b/src/commands/adjustmentCommands.ts
@@ -2,6 +2,7 @@ import type { App, Editor } from 'obsidian';
 import type {
   AdjustmentOperation,
   ConversionSettings,
+  HeadingPlacement,
   LinePlacement,
 } from '../contracts';
 import { Notice } from 'obsidian';
@@ -32,6 +33,8 @@ export interface CommandContext {
   defaultLevel(operation: AdjustmentOperation): number;
   /** Which overflow conversions are switched on, for the same reason. */
   conversion(): ConversionSettings;
+  /** Where the toggle is pointed, for the same reason again. */
+  toggleTarget(): HeadingPlacement;
 }
 
 /** Asks for a shift and a range, then adjusts what the user named. */
@@ -114,7 +117,9 @@ export function placeCurrentLine(
 ): void {
   const editor = requireActiveEditor(context);
   if (editor) {
-    placeEditorLine(editor, placement);
+    // Asked for now rather than when the command was registered, so a setting
+    // changed mid-session takes effect without a reload.
+    placeEditorLine(editor, placement, context.toggleTarget());
   }
 }
 

--- a/src/commands/commandSurfaces.ts
+++ b/src/commands/commandSurfaces.ts
@@ -42,6 +42,7 @@ const OPERATIONS: AdjustmentOperation[] = ['increase', 'decrease'];
  * because the group it sits in already said so.
  */
 const PLACEMENTS: Array<[LinePlacement, string, string]> = [
+  ['toggle', 'Toggle heading on current line', 'Toggle heading'],
   ['plain', 'Remove heading from current line', 'Remove heading'],
   [
     'sibling',

--- a/src/commands/icons.ts
+++ b/src/commands/icons.ts
@@ -38,9 +38,19 @@ export const SHIFT_ICON: Record<ShiftScope, Record<AdjustmentOperation, string>>
  * These name a level rather than a direction, so they say what the line becomes
  * instead of which way it moves: the markup stripped off, a level held equal, a
  * step in and down.
+ *
+ * The toggle takes the `#` itself, because it is the one that does both and is
+ * the one a user with a single free toolbar slot will spend it on. Typing the
+ * character it adds and removes says more there than any arrow could.
+ *
+ * `root` is here without a command of its own: it is reachable by pointing the
+ * toggle at it, and the record is kept whole so that the day it earns a command
+ * the symbol is already chosen rather than picked in a hurry.
  */
 export const PLACEMENT_ICON: Record<LinePlacement, string> = {
+  toggle: 'hash',
   plain: 'remove-formatting',
+  root: 'heading-1',
   sibling: 'equal',
   child: 'corner-down-right',
 };

--- a/src/contracts.d.ts
+++ b/src/contracts.d.ts
@@ -15,15 +15,29 @@
 export type AdjustmentOperation = 'increase' | 'decrease';
 
 /**
+ * The three ways of naming a level for a line that is to be a heading.
+ *
+ * `root` is the top of the note and answers to nothing above it. The other two
+ * are read against the enclosing heading, the nearest heading above the line:
+ * `sibling` takes its level, `child` one deeper. These are also the three a
+ * toggle can be pointed at, which is why they are a word of their own.
+ */
+export type HeadingPlacement = 'root' | 'sibling' | 'child';
+
+/**
  * Where the current line's heading sits relative to the section it is in.
  *
  * These name a level outright instead of a distance to move, which is what
- * separates them from an operation: nothing about them reads how deep the line
- * is written now. `plain` is level zero — no heading at all — and is how one is
- * taken away. The other two are read against the enclosing heading, the nearest
- * heading above the line.
+ * separates them from an operation. `plain` is level zero — no heading at all —
+ * and is how one is taken away.
+ *
+ * `toggle` is the one that also reads the line: it is whichever
+ * `HeadingPlacement` the user pointed it at, unless the line is already sitting
+ * there, in which case there is nothing left to add and it is `plain` instead.
+ * That makes one command out of two, which is what a mobile toolbar with a
+ * single free slot has room for.
  */
-export type LinePlacement = 'plain' | 'sibling' | 'child';
+export type LinePlacement = HeadingPlacement | 'plain' | 'toggle';
 
 /**
  * Why an adjustment produced nothing.
@@ -62,6 +76,8 @@ export interface HeadingAdjusterSettings extends ConversionSettings {
   increaseLevel: number;
   decreaseLevel: number;
   deepestHeadingLevel: number;
+  /** Which level the toggle puts a heading at, and so which one takes it off. */
+  toggleTarget: HeadingPlacement;
 }
 
 /** Whatever owns the settings and can persist them. */

--- a/src/core/adjustHeadings.ts
+++ b/src/core/adjustHeadings.ts
@@ -1,6 +1,7 @@
 import type {
   AdjustmentOperation,
   ConversionSettings,
+  HeadingPlacement,
   LinePlacement,
   RejectionReason,
 } from '../contracts';
@@ -119,11 +120,12 @@ export function adjustHeadings(
 export function placeLineHeading(
   lines: readonly string[],
   lineNumber: number,
-  placement: LinePlacement
+  placement: LinePlacement,
+  target: HeadingPlacement = 'sibling'
 ): AdjustmentOutcome {
   const fenced = computeFencedLines(lines);
   const above = parseHeadings(lines, 0, lineNumber - 1, fenced);
-  const edits = placeLineLevel(lines, fenced, lineNumber, placement, above);
+  const edits = placeLineLevel(lines, fenced, lineNumber, placement, above, target);
 
   return { status: 'adjusted', edits, changedCount: edits.length, truncatedSections: 0 };
 }

--- a/src/core/line/line.ts
+++ b/src/core/line/line.ts
@@ -1,4 +1,8 @@
-import type { AdjustmentOperation, LinePlacement } from '../../contracts';
+import type {
+  AdjustmentOperation,
+  HeadingPlacement,
+  LinePlacement,
+} from '../../contracts';
 import type { LeveledLine } from './placement';
 import { enclosingLevel, placedLevel } from './placement';
 import { listMarkerWidth } from './marker';
@@ -67,21 +71,27 @@ export function adjustLineLevel(
  * when it is already there.
  *
  * The counterpart to shifting. A placement names a level outright, worked out
- * from the outline rather than from the line, so what the line is written at
- * now is read only to know what has to be replaced.
+ * from the outline rather than from the line — except `toggle`, which asks the
+ * line whether it is already there, and is why the level goes to `placedLevel`
+ * rather than being settled before `writeLine` is called.
  *
  * @param above The headings preceding the line, nearest last. The last of them
  *   is the enclosing heading, and the whole of what a placement reads.
+ * @param target Where a toggle is pointed, which the user chooses. Ignored by
+ *   every other placement.
  */
 export function placeLineLevel(
   lines: readonly string[],
   fenced: readonly boolean[],
   lineNumber: number,
   placement: LinePlacement,
-  above: readonly LeveledLine[]
+  above: readonly LeveledLine[],
+  target: HeadingPlacement
 ): LineLevelEdit[] {
-  const target = placedLevel(placement, enclosingLevel(above));
-  return writeLine(lines, fenced, lineNumber, () => target);
+  const enclosing = enclosingLevel(above);
+  return writeLine(lines, fenced, lineNumber, (level) =>
+    placedLevel(placement, enclosing, level, target)
+  );
 }
 
 /**

--- a/src/core/line/placement.ts
+++ b/src/core/line/placement.ts
@@ -1,4 +1,4 @@
-import type { LinePlacement } from '../../contracts';
+import type { HeadingPlacement, LinePlacement } from '../../contracts';
 
 /**
  * Which level a line's heading takes when it is placed rather than moved.
@@ -34,10 +34,37 @@ export function enclosingLevel(above: readonly LeveledLine[]): number {
   return above[above.length - 1]?.level ?? 0;
 }
 
-/** The level a placement asks for, before the writer clamps it to what Markdown has. */
-export function placedLevel(placement: LinePlacement, enclosing: number): number {
+/**
+ * The level a placement asks for, before the writer clamps it to what Markdown
+ * has.
+ *
+ * @param level What the line is written at now. Only `toggle` reads it: the
+ *   others say where the line belongs without looking at where it is.
+ * @param target Where a toggle is pointed. Ignored by every other placement.
+ */
+export function placedLevel(
+  placement: LinePlacement,
+  enclosing: number,
+  level: number,
+  target: HeadingPlacement
+): number {
   if (placement === 'plain') {
     return 0;
+  }
+
+  // A toggle is its target read twice. Aiming at it turns a plain line into a
+  // heading; finding the line already there means the only move left is off,
+  // which is what makes one press create a section and the next remove it.
+  const aim = placement === 'toggle' ? target : placement;
+  const aimed = headingLevel(aim, enclosing);
+
+  return placement === 'toggle' && level === aimed ? 0 : aimed;
+}
+
+/** The level one of the three heading placements names. */
+function headingLevel(placement: HeadingPlacement, enclosing: number): number {
+  if (placement === 'root') {
+    return MIN_HEADING_LEVEL;
   }
   if (placement === 'child') {
     return enclosing + 1;

--- a/src/editor/headingAdjustmentService.ts
+++ b/src/editor/headingAdjustmentService.ts
@@ -2,6 +2,7 @@ import type { Editor } from 'obsidian';
 import type {
   AdjustmentOperation,
   ConversionSettings,
+  HeadingPlacement,
   LinePlacement,
   RejectionReason,
 } from '../contracts';
@@ -87,10 +88,14 @@ export function adjustEditorLine(
  * the level that follows from that is the same whichever level it is written at
  * now.
  */
-export function placeEditorLine(editor: Editor, placement: LinePlacement): void {
+export function placeEditorLine(
+  editor: Editor,
+  placement: LinePlacement,
+  target: HeadingPlacement
+): void {
   applyOutcome(
     editor,
-    placeLineHeading(readEditorLines(editor), cursorLine(editor), placement)
+    placeLineHeading(readEditorLines(editor), cursorLine(editor), placement, target)
   );
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import type {
   AdjustmentOperation,
   ConversionSettings,
   HeadingAdjusterSettings,
+  HeadingPlacement,
   SettingsHost,
 } from './contracts';
 import { Plugin } from 'obsidian';
@@ -47,5 +48,10 @@ export default class HeadingAdjusterPlugin extends Plugin implements SettingsHos
   /** Which conversions are switched on. Also satisfies `CommandContext`. */
   conversion(): ConversionSettings {
     return this.settings;
+  }
+
+  /** Where the toggle is pointed. The third thing a command may ask. */
+  toggleTarget(): HeadingPlacement {
+    return this.settings.toggleTarget;
   }
 }

--- a/src/settings/controls.ts
+++ b/src/settings/controls.ts
@@ -1,0 +1,98 @@
+import type {
+  SettingDropdownControl,
+  SettingSliderControl,
+  SettingToggleControl,
+} from 'obsidian';
+import type { HeadingPlacement } from '../contracts';
+
+/**
+ * What the settings are, said once and in one place.
+ *
+ * Kept apart from the tab because the two answer different questions: this
+ * file is the list of settings the plugin has, and `settingsTab.ts` is how
+ * Obsidian is handed them. Both of its rendering paths read this list, so
+ * neither can come to describe a setting the other does not have.
+ */
+
+/**
+ * How far each slider may travel: a default shift of one to five levels, and a
+ * ceiling anywhere in Markdown's own range, six being that range's end and so
+ * the setting having no effect.
+ */
+const RANGE = {
+  level: { min: 1, max: 5, step: 1 },
+  ceiling: { min: 1, max: 6, step: 1 },
+} as const;
+
+/** The settings a slider can be bound to. */
+type LevelKey = 'increaseLevel' | 'decreaseLevel' | 'deepestHeadingLevel';
+
+/** The settings a toggle can be bound to. */
+type ToggleKey = 'headingsToBullets' | 'bulletsToHeadings';
+
+/** Where the toggle command may be pointed, in the user's words. */
+export const TOGGLE_TARGETS: Record<HeadingPlacement, string> = {
+  root: 'Top level (#)',
+  sibling: 'Same level as the heading above',
+  child: 'One level below the heading above',
+};
+
+/**
+ * One setting, described rather than drawn.
+ *
+ * Narrower than Obsidian's own `SettingDefinitionItem`, which also covers
+ * groups, pages and lists this plugin has no use for. Naming the three controls
+ * it does use is what lets the tab read a key and get back the type the setting
+ * actually holds.
+ */
+export type ControlDefinition = {
+  name: string;
+  desc: string;
+  control:
+    | SettingSliderControl<LevelKey>
+    | SettingToggleControl<ToggleKey>
+    | SettingDropdownControl<'toggleTarget'>;
+};
+
+/** Every setting there is, said once. */
+export const SETTINGS: ControlDefinition[] = [
+  {
+    name: 'Default increase level',
+    desc: 'The default number of levels to increase headings by.',
+    control: { type: 'slider', key: 'increaseLevel', ...RANGE.level },
+  },
+  {
+    name: 'Default decrease level',
+    desc: 'The default number of levels to decrease headings by.',
+    control: { type: 'slider', key: 'decreaseLevel', ...RANGE.level },
+  },
+  {
+    name: 'Deepest heading level',
+    desc: 'The level headings stop at. Anything an increase would push past it '
+      + 'becomes a bulleted list item instead, and a bullet converted back '
+      + 'returns to this level. Only has an effect with a conversion below '
+      + 'switched on.',
+    control: { type: 'slider', key: 'deepestHeadingLevel', ...RANGE.ceiling },
+  },
+  {
+    name: 'Toggle puts the heading at',
+    desc: 'Which level "Toggle heading on current line" writes, and so which level '
+      + 'it takes back off. A line already at that level loses its heading; a '
+      + 'line anywhere else is moved to it first.',
+    control: { type: 'dropdown', key: 'toggleTarget', options: TOGGLE_TARGETS },
+  },
+  {
+    name: 'Convert headings past the deepest level into bullets',
+    desc: 'When increasing would push a heading past the level above, turn it into a '
+      + 'bulleted list item instead of leaving it unchanged. The content beneath '
+      + 'the heading is re-indented so it sits inside the new bullet.',
+    control: { type: 'toggle', key: 'headingsToBullets' },
+  },
+  {
+    name: 'Convert bullets back into headings',
+    desc: 'When decreasing, turn list items back into headings. Warning: this cannot '
+      + 'tell a bullet this plugin created from one you typed yourself, so every '
+      + 'list in range is converted — including hand-written ones.',
+    control: { type: 'toggle', key: 'bulletsToHeadings' },
+  },
+];

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -23,6 +23,9 @@ const DEFAULT_SETTINGS: HeadingAdjusterSettings = {
   bulletsToHeadings: false,
   // Markdown's own limit, which is this setting having no effect.
   deepestHeadingLevel: 6,
+  // What the toggle did before it could be pointed anywhere else, so an
+  // upgrade finds the command behaving exactly as it left it.
+  toggleTarget: 'sibling',
 };
 
 /** The stored settings, with anything missing filled in from the defaults. */

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -1,78 +1,16 @@
-import type {
-  App,
-  Plugin,
-  SettingDefinitionItem,
-  SettingSliderControl,
-  SettingToggleControl,
-} from 'obsidian';
-import type { SettingsHost } from '../contracts';
+import type { App, Plugin, SettingDefinitionItem } from 'obsidian';
+import type { HeadingPlacement, SettingsHost } from '../contracts';
+import type { ControlDefinition } from './controls';
 import { PluginSettingTab, Setting } from 'obsidian';
+import { SETTINGS, TOGGLE_TARGETS } from './controls';
 
 /**
- * How far each slider may travel: a default shift of one to five levels, and a
- * ceiling anywhere in Markdown's own range, six being that range's end and so
- * the setting having no effect.
- */
-const RANGE = {
-  level: { min: 1, max: 5, step: 1 },
-  ceiling: { min: 1, max: 6, step: 1 },
-} as const;
-
-/** The settings a slider can be bound to. */
-type LevelKey = 'increaseLevel' | 'decreaseLevel' | 'deepestHeadingLevel';
-
-/** The settings a toggle can be bound to. */
-type ToggleKey = 'headingsToBullets' | 'bulletsToHeadings';
-
-/**
- * One setting, described rather than drawn.
+ * How Obsidian is handed the settings — described where it can, drawn where it
+ * cannot.
  *
- * Narrower than Obsidian's own `SettingDefinitionItem`, which also covers
- * groups, pages and lists this plugin has no use for. Naming the two controls
- * it does use is what lets `display()` below read a key and get back the type
- * the setting actually holds.
+ * What the settings are lives in `controls.ts`; this file is only the two ways
+ * of putting them on screen and the reading and writing of one by key.
  */
-type ControlDefinition = {
-  name: string;
-  desc: string;
-  control: SettingSliderControl<LevelKey> | SettingToggleControl<ToggleKey>;
-};
-
-/** Every setting there is, said once. */
-const SETTINGS: ControlDefinition[] = [
-  {
-    name: 'Default increase level',
-    desc: 'The default number of levels to increase headings by.',
-    control: { type: 'slider', key: 'increaseLevel', ...RANGE.level },
-  },
-  {
-    name: 'Default decrease level',
-    desc: 'The default number of levels to decrease headings by.',
-    control: { type: 'slider', key: 'decreaseLevel', ...RANGE.level },
-  },
-  {
-    name: 'Deepest heading level',
-    desc: 'The level headings stop at. Anything an increase would push past it '
-      + 'becomes a bulleted list item instead, and a bullet converted back '
-      + 'returns to this level. Only has an effect with a conversion below '
-      + 'switched on.',
-    control: { type: 'slider', key: 'deepestHeadingLevel', ...RANGE.ceiling },
-  },
-  {
-    name: 'Convert headings past the deepest level into bullets',
-    desc: 'When increasing would push a heading past the level above, turn it into a '
-      + 'bulleted list item instead of leaving it unchanged. The content beneath '
-      + 'the heading is re-indented so it sits inside the new bullet.',
-    control: { type: 'toggle', key: 'headingsToBullets' },
-  },
-  {
-    name: 'Convert bullets back into headings',
-    desc: 'When decreasing, turn list items back into headings. Warning: this cannot '
-      + 'tell a bullet this plugin created from one you typed yourself, so every '
-      + 'list in range is converted — including hand-written ones.',
-    control: { type: 'toggle', key: 'bulletsToHeadings' },
-  },
-];
 
 export class HeadingAdjusterSettingTab extends PluginSettingTab {
   private readonly host: SettingsHost;
@@ -108,6 +46,8 @@ export class HeadingAdjusterSettingTab extends PluginSettingTab {
       settings[control.key] = value;
     } else if (control?.type === 'toggle' && typeof value === 'boolean') {
       settings[control.key] = value;
+    } else if (control?.type === 'dropdown' && isTarget(value)) {
+      settings[control.key] = value;
     } else {
       return Promise.resolve();
     }
@@ -128,25 +68,57 @@ export class HeadingAdjusterSettingTab extends PluginSettingTab {
     containerEl.empty();
 
     for (const { name, desc, control } of SETTINGS) {
-      const setting = new Setting(containerEl).setName(name).setDesc(desc);
-
-      if (control.type === 'slider') {
-        setting.addSlider((slider) =>
-          slider
-            .setLimits(control.min, control.max, control.step)
-            .setValue(this.host.settings[control.key])
-            .setDynamicTooltip()
-            .onChange((value) => void this.setControlValue(control.key, value))
-        );
-      } else {
-        setting.addToggle((toggle) =>
-          toggle
-            .setValue(this.host.settings[control.key])
-            .onChange((value) => void this.setControlValue(control.key, value))
-        );
-      }
+      this.draw(new Setting(containerEl).setName(name).setDesc(desc), control);
     }
   }
+
+  /**
+   * Puts one control on screen and wires it back to the setting it holds.
+   *
+   * Split out of `display()` because a control per kind, each a chain inside a
+   * callback inside a branch inside a loop, is nesting a reader has to unpick
+   * rather than read. `store` is shared: the three components hand back three
+   * different types and `setControlValue` is what decides which are real, so
+   * there is nothing per-kind to say here.
+   */
+  private draw(setting: Setting, control: ControlDefinition['control']): void {
+    const store = (value: unknown) => void this.setControlValue(control.key, value);
+
+    if (control.type === 'slider') {
+      setting.addSlider((slider) =>
+        slider
+          .setLimits(control.min, control.max, control.step)
+          .setValue(this.host.settings[control.key])
+          .setDynamicTooltip()
+          .onChange(store)
+      );
+      return;
+    }
+
+    if (control.type === 'dropdown') {
+      setting.addDropdown((dropdown) =>
+        dropdown
+          .addOptions(control.options)
+          .setValue(this.host.settings[control.key])
+          .onChange(store)
+      );
+      return;
+    }
+
+    setting.addToggle((toggle) =>
+      toggle.setValue(this.host.settings[control.key]).onChange(store)
+    );
+  }
+}
+
+/**
+ * Whether a value is one of the three places a toggle may be pointed.
+ *
+ * A stored setting is whatever the file held, so the dropdown's own options are
+ * what say which strings are real — the same list the user picked from.
+ */
+function isTarget(value: unknown): value is HeadingPlacement {
+  return typeof value === 'string' && value in TOGGLE_TARGETS;
 }
 
 /** The control bound to `key`, or nothing if this tab does not own it. */

--- a/tests/commands/adjustmentCommands.test.ts
+++ b/tests/commands/adjustmentCommands.test.ts
@@ -56,6 +56,7 @@ function fakeContext(
     },
     defaultLevel: () => 1,
     conversion: () => conversion,
+    toggleTarget: () => 'sibling',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
@@ -242,5 +243,51 @@ describe('the placement commands find the editor the user is in', () => {
     assert.doesNotThrow(() =>
       placeCurrentLine(fakeContext(null, {}, 'neither'), 'plain')
     );
+  });
+});
+
+describe('the toggle command needs only the one binding', () => {
+  /** The document after toggling line 1, with the toggle pointed at `target`. */
+  function toggled(lines: string[], target: string): string {
+    const editor = fakeEditor([...lines], [], 1);
+    const context = fakeContext(editor, {});
+    context.toggleTarget = () => target;
+
+    placeCurrentLine(context, 'toggle');
+
+    return written(editor, lines);
+  }
+
+  test('the same command puts a heading on and takes it off again', () => {
+    assert.equal(toggled(['## Setup', 'some prose'], 'sibling'), '## Setup\n## some prose');
+    assert.equal(toggled(['## Setup', '## some prose'], 'sibling'), '## Setup\nsome prose');
+  });
+
+  test('it goes wherever the plugin says it is pointed', () => {
+    const before = ['## Setup', 'some prose'];
+
+    assert.equal(toggled(before, 'root'), '## Setup\n# some prose');
+    assert.equal(toggled(before, 'sibling'), '## Setup\n## some prose');
+    assert.equal(toggled(before, 'child'), '## Setup\n### some prose');
+  });
+
+  test('each target takes off only the level it puts on', () => {
+    const on = ['## Setup', '### some prose'];
+
+    assert.equal(toggled(on, 'child'), '## Setup\nsome prose');
+    assert.equal(toggled(on, 'sibling'), '## Setup\n## some prose');
+  });
+
+  test('the target is read at press time, not when the command was registered', () => {
+    const before = ['## Setup', 'some prose'];
+    const editor = fakeEditor([...before], [], 1);
+    const context = fakeContext(editor, {});
+    let target = 'sibling';
+    context.toggleTarget = () => target;
+
+    target = 'child';
+    placeCurrentLine(context, 'toggle');
+
+    assert.equal(written(editor, before), '## Setup\n### some prose');
   });
 });

--- a/tests/commands/icons.test.ts
+++ b/tests/commands/icons.test.ts
@@ -37,7 +37,7 @@ describe('every action carries a symbol', () => {
   const commands = registeredCommands();
 
   test('there is a command for each scope in each direction, plus the placements', () => {
-    assert.equal(commands.length, 11);
+    assert.equal(commands.length, 12);
   });
 
   for (const command of commands) {

--- a/tests/core/adjustHeadings.test.ts
+++ b/tests/core/adjustHeadings.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
+import type { LinePlacement } from '../../src/contracts';
 import { adjustHeadings, placeLineHeading } from '../../src/core/adjustHeadings';
 import { applyHeadingEdits } from '../../src/core/headingEdits';
 import { adjust, doc } from '../support/document';
@@ -445,7 +446,7 @@ describe('placing the current line against the section it sits in', () => {
   function place(
     markdown: string,
     lineNumber: number,
-    placement: 'plain' | 'sibling' | 'child'
+    placement: LinePlacement
   ): { text: string; changedCount: number } {
     const lines = markdown.split('\n');
     const outcome = placeLineHeading(lines, lineNumber, placement);
@@ -634,6 +635,35 @@ describe('placing the current line against the section it sits in', () => {
     const { changedCount } = place('## Setup\n- item', 1, 'plain');
 
     assert.equal(changedCount, 0);
+  });
+
+  test('a toggle reads the outline for what to put on, and the line for whether to', () => {
+    const before = doc`
+      # Guide
+      ## Setup
+      some prose
+    `;
+
+    const on = place(before, 2, 'toggle');
+    assert.equal(
+      on.text,
+      doc`
+        # Guide
+        ## Setup
+        ## some prose
+      `
+    );
+    assert.equal(on.changedCount, 1);
+
+    const off = place(on.text, 2, 'toggle');
+    assert.equal(off.text, before);
+    assert.equal(off.changedCount, 1);
+  });
+
+  test('a toggle under a fenced heading answers to the real one above', () => {
+    const { text } = place('## Setup\n```\n### fake\n```\nsome prose', 4, 'toggle');
+
+    assert.equal(text, '## Setup\n```\n### fake\n```\n## some prose');
   });
 
   test('a line already where the placement wants it is nothing to do', () => {

--- a/tests/core/line/line.test.ts
+++ b/tests/core/line/line.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
+import type { LinePlacement } from '../../../src/contracts';
 import { adjustLineLevel, placeLineLevel } from '../../../src/core/line/line';
 
 /**
@@ -115,11 +116,11 @@ describe('writing a line at the level its placement asks for', () => {
   /** The line as `placeLineLevel` would leave it, under a heading of `enclosing`. */
   function placed(
     line: string,
-    placement: 'plain' | 'sibling' | 'child',
+    placement: LinePlacement,
     enclosing = 0
   ): string {
     const above = enclosing > 0 ? [{ level: enclosing }] : [];
-    const [edit] = placeLineLevel([line], [], 0, placement, above);
+    const [edit] = placeLineLevel([line], [], 0, placement, above, 'sibling');
 
     return edit
       ? line.slice(0, edit.fromColumn) + edit.text + line.slice(edit.toColumn)
@@ -145,12 +146,12 @@ describe('writing a line at the level its placement asks for', () => {
   });
 
   test('a line already where the placement wants it is nothing to write', () => {
-    assert.deepEqual(placeLineLevel(['## A'], [], 0, 'sibling', [{ level: 2 }]), []);
-    assert.deepEqual(placeLineLevel(['A'], [], 0, 'plain', []), []);
+    assert.deepEqual(placeLineLevel(['## A'], [], 0, 'sibling', [{ level: 2 }], 'sibling'), []);
+    assert.deepEqual(placeLineLevel(['A'], [], 0, 'plain', [], 'sibling'), []);
   });
 
   test('a line the document reads as code is left alone', () => {
-    assert.deepEqual(placeLineLevel(['# A'], [true], 0, 'child', [{ level: 2 }]), []);
+    assert.deepEqual(placeLineLevel(['# A'], [true], 0, 'child', [{ level: 2 }], 'sibling'), []);
   });
 });
 
@@ -179,5 +180,48 @@ describe('writing a heading onto a line that is already a bullet', () => {
 
   test('a heading taken back off does not become a bullet again', () => {
     assert.equal(moved('# Some prose', 'decrease'), 'Some prose');
+  });
+});
+
+describe('toggling a heading on and off the current line', () => {
+  /** The line as a toggle would leave it, under a heading of `enclosing`. */
+  function toggled(line: string, enclosing = 0): string {
+    const above = enclosing > 0 ? [{ level: enclosing }] : [];
+    const [edit] = placeLineLevel([line], [], 0, 'toggle', above, 'sibling');
+
+    return edit
+      ? line.slice(0, edit.fromColumn) + edit.text + line.slice(edit.toColumn)
+      : line;
+  }
+
+  test('writes a heading onto a plain line at the enclosing level', () => {
+    assert.equal(toggled('Some prose', 2), '## Some prose');
+  });
+
+  test('takes it back off when the line is already sitting there', () => {
+    assert.equal(toggled('## Some prose', 2), 'Some prose');
+  });
+
+  test('one press then another returns the line it started from', () => {
+    assert.equal(toggled(toggled('Some prose', 3), 3), 'Some prose');
+    assert.equal(toggled(toggled('### Some prose', 3), 3), '### Some prose');
+  });
+
+  test('a heading at some other level is levelled first, not removed', () => {
+    assert.equal(toggled('##### Some prose', 2), '## Some prose');
+    assert.equal(toggled('# Some prose', 3), '### Some prose');
+  });
+
+  test('with nothing above, it is an H1 that goes on and off', () => {
+    assert.equal(toggled('Some prose'), '# Some prose');
+    assert.equal(toggled('# Some prose'), 'Some prose');
+  });
+
+  test('takes a bullet away on the way in, like the other placements', () => {
+    assert.equal(toggled('- Some prose', 2), '## Some prose');
+  });
+
+  test('a line the document reads as code is left alone', () => {
+    assert.deepEqual(placeLineLevel(['# A'], [true], 0, 'toggle', [], 'sibling'), []);
   });
 });

--- a/tests/core/line/placement.test.ts
+++ b/tests/core/line/placement.test.ts
@@ -25,24 +25,90 @@ describe('the enclosing level', () => {
 
 describe('the level a placement asks for', () => {
   test('plain is level zero — no heading at all', () => {
-    assert.equal(placedLevel('plain', 3), 0);
-    assert.equal(placedLevel('plain', 0), 0);
+    assert.equal(placedLevel('plain', 3, 0, 'sibling'), 0);
+    assert.equal(placedLevel('plain', 0, 0, 'sibling'), 0);
   });
 
   test('a sibling sits at the enclosing heading level', () => {
-    assert.equal(placedLevel('sibling', 3), 3);
+    assert.equal(placedLevel('sibling', 3, 0, 'sibling'), 3);
   });
 
   test('a child sits one level deeper', () => {
-    assert.equal(placedLevel('child', 3), 4);
+    assert.equal(placedLevel('child', 3, 0, 'sibling'), 4);
   });
 
   test('with nothing above, a sibling of the note itself is an H1', () => {
-    assert.equal(placedLevel('sibling', 0), 1);
-    assert.equal(placedLevel('child', 0), 1);
+    assert.equal(placedLevel('sibling', 0, 0, 'sibling'), 1);
+    assert.equal(placedLevel('child', 0, 0, 'sibling'), 1);
   });
 
   test('asks past the Markdown limit rather than clamping — the writer does that', () => {
-    assert.equal(placedLevel('child', 6), 7);
+    assert.equal(placedLevel('child', 6, 0, 'sibling'), 7);
+  });
+
+  test('the three that name a level do not read the one the line is at', () => {
+    for (const level of [0, 1, 3, 6]) {
+      assert.equal(placedLevel('plain', 2, level, 'sibling'), 0);
+      assert.equal(placedLevel('sibling', 2, level, 'sibling'), 2);
+      assert.equal(placedLevel('child', 2, level, 'sibling'), 3);
+    }
+  });
+});
+
+describe('the level a root placement asks for', () => {
+  test('is the top of the note, whatever sits above the line', () => {
+    assert.equal(placedLevel('root', 0, 0, 'sibling'), 1);
+    assert.equal(placedLevel('root', 4, 3, 'sibling'), 1);
+  });
+});
+
+describe('where a toggle is pointed', () => {
+  test('follows its target rather than assuming a sibling', () => {
+    assert.equal(placedLevel('toggle', 2, 0, 'root'), 1);
+    assert.equal(placedLevel('toggle', 2, 0, 'sibling'), 2);
+    assert.equal(placedLevel('toggle', 2, 0, 'child'), 3);
+  });
+
+  test('comes off when the line is at whichever level it was pointed at', () => {
+    assert.equal(placedLevel('toggle', 2, 1, 'root'), 0);
+    assert.equal(placedLevel('toggle', 2, 2, 'sibling'), 0);
+    assert.equal(placedLevel('toggle', 2, 3, 'child'), 0);
+  });
+
+  test('a line at the wrong one of the three is moved, not removed', () => {
+    assert.equal(placedLevel('toggle', 2, 2, 'child'), 3);
+    assert.equal(placedLevel('toggle', 2, 3, 'sibling'), 2);
+  });
+
+  test('the target is ignored by every placement that is not a toggle', () => {
+    for (const target of ['root', 'sibling', 'child'] as const) {
+      assert.equal(placedLevel('sibling', 4, 0, target), 4);
+      assert.equal(placedLevel('child', 4, 0, target), 5);
+      assert.equal(placedLevel('plain', 4, 0, target), 0);
+    }
+  });
+});
+
+describe('the level a toggle asks for', () => {
+  test('aims at the sibling level from anywhere else', () => {
+    assert.equal(placedLevel('toggle', 2, 0, 'sibling'), 2);
+    assert.equal(placedLevel('toggle', 2, 1, 'sibling'), 2);
+    assert.equal(placedLevel('toggle', 2, 5, 'sibling'), 2);
+  });
+
+  test('comes off once the line is already sitting there', () => {
+    assert.equal(placedLevel('toggle', 2, 2, 'sibling'), 0);
+  });
+
+  test('with nothing above, it is an H1 that toggles', () => {
+    assert.equal(placedLevel('toggle', 0, 0, 'sibling'), 1);
+    assert.equal(placedLevel('toggle', 0, 1, 'sibling'), 0);
+  });
+
+  test('two presses reach plain text from any level', () => {
+    for (const level of [0, 1, 3, 6]) {
+      const first = placedLevel('toggle', 3, level, 'sibling');
+      assert.equal(placedLevel('toggle', 3, first, 'sibling'), first === 0 ? 3 : 0);
+    }
   });
 });

--- a/tests/editor/headingAdjustmentService.test.ts
+++ b/tests/editor/headingAdjustmentService.test.ts
@@ -194,7 +194,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', 'some prose', '### C'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'child');
+    placeEditorLine(asEditor(editor), 'child', 'sibling');
 
     assert.equal(written(editor, before), '## A\n### some prose\n### C');
   });
@@ -203,7 +203,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', '#### B'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'plain');
+    placeEditorLine(asEditor(editor), 'plain', 'sibling');
 
     assert.equal(written(editor, before), '## A\nB');
   });
@@ -212,7 +212,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', '### B'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'child');
+    placeEditorLine(asEditor(editor), 'child', 'sibling');
 
     assert.deepEqual(editor.transactions, []);
   });

--- a/tests/settings/settings.test.ts
+++ b/tests/settings/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
+import type { HeadingAdjusterSettings } from '../../src/contracts';
 import { defaultLevelFor, readSettings } from '../../src/settings/settings';
 
 /** A plugin as far as `readSettings` is concerned: something with stored data. */
@@ -10,12 +11,13 @@ function pluginStoring(data: unknown) {
 
 describe('defaultLevelFor', () => {
   test('picks the shift configured for the direction being asked about', () => {
-    const settings = {
+    const settings: HeadingAdjusterSettings = {
       increaseLevel: 2,
       decreaseLevel: 3,
       headingsToBullets: false,
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
+      toggleTarget: 'sibling',
     };
 
     assert.equal(defaultLevelFor(settings, 'increase'), 2);
@@ -31,6 +33,7 @@ describe('readSettings', () => {
       headingsToBullets: false,
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
+      toggleTarget: 'sibling',
     });
   });
 
@@ -48,6 +51,7 @@ describe('readSettings', () => {
       headingsToBullets: false,
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
+      toggleTarget: 'sibling',
     });
   });
 });

--- a/tests/settings/settingsTab.test.ts
+++ b/tests/settings/settingsTab.test.ts
@@ -14,6 +14,9 @@ import { HeadingAdjusterSettingTab } from '../../src/settings/settingsTab';
  * of them touches the DOM.
  */
 
+/** The three kinds of control this plugin binds, and nothing else. */
+const CONTROL_TYPES = ['slider', 'toggle', 'dropdown'];
+
 async function defaults(): Promise<HeadingAdjusterSettings> {
   return readSettings({ loadData: async () => null } as never);
 }
@@ -132,5 +135,55 @@ describe('setControlValue', () => {
 
     assert.deepEqual(settings, await defaults());
     assert.deepEqual(saves, []);
+  });
+});
+
+describe('the toggle target dropdown', () => {
+  test('offers exactly the three places a toggle can be pointed', async () => {
+    const { tab } = tabFor(await defaults());
+    const control = controls(tab).find((each) => each.key === 'toggleTarget');
+
+    assert.ok(control && control.type === 'dropdown');
+    assert.deepEqual(Object.keys(control.options), ['root', 'sibling', 'child']);
+  });
+
+  test('a chosen target is stored and persisted', async () => {
+    const settings = await defaults();
+    const { tab, saves } = tabFor(settings);
+
+    await tab.setControlValue('toggleTarget', 'child');
+
+    assert.equal(settings.toggleTarget, 'child');
+    assert.equal(saves.length, 1);
+  });
+
+  test('a string that is not one of the three is refused rather than stored', async () => {
+    const settings = await defaults();
+    const { tab, saves } = tabFor(settings);
+
+    await tab.setControlValue('toggleTarget', 'grandchild');
+
+    assert.equal(settings.toggleTarget, 'sibling');
+    assert.deepEqual(saves, []);
+  });
+
+  test('a value of the wrong type entirely is refused too', async () => {
+    const settings = await defaults();
+    const { tab } = tabFor(settings);
+
+    await tab.setControlValue('toggleTarget', 3);
+
+    assert.equal(settings.toggleTarget, 'sibling');
+  });
+
+  test('every control the tab binds is one of the kinds it knows how to draw', async () => {
+    const { tab } = tabFor(await defaults());
+
+    for (const control of controls(tab)) {
+      assert.ok(
+        CONTROL_TYPES.includes(control.type),
+        `${control.key} is a ${control.type}, which display() would draw as a toggle`
+      );
+    }
   });
 });


### PR DESCRIPTION
Making a section and unmaking it were two commands, which is two hotkeys and two toolbar slots. A user on Android reported having exactly one slot left, and reaching for anything else being disruptive enough to change how they work. That is the case this is built for: the two halves have to fit in one binding.

## The command

**Toggle heading on current line**, icon `hash` — the `#` it adds and removes.

| Toggle set to | Once | Twice |
| --- | --- | --- |
| Top level | `# some prose` | `some prose` |
| Same level as the heading above *(default)* | `## some prose` | `some prose` |
| One level below the heading above | `### some prose` | `some prose` |

Where it aims is the user's to choose, under **Toggle puts the heading at** in settings, because which of those counts as "a heading here" depends on how someone writes. It ships pointed at `sibling`, so an upgrade finds the command doing what it did before the setting existed. The target is read when the command runs, not when it was registered, so a change takes effect without a reload — the same as the default shift and the conversions.

A heading at some *other* level is moved to the chosen one rather than removed, so the second press is what takes it off. Two presses reach plain text from anywhere, no single press destroys a level that would have to be retyped, and the toggle only removes the level it puts on — pointed at `child`, it moves a sibling heading instead of deleting it. That last part is what makes headings usable as the temporary markers they were being used as.

## How it fits

A toggle is a placement read twice: aim at a level, and if the line is already there the only move left is off. `writeLine` already hands the level chooser what the line is written at, so nothing new had to be threaded to see it.

Once the toggle can aim at three places, `toggle` is clearly not *where* a line goes. `root`, `sibling` and `child` became a word of their own — `HeadingPlacement` — with a toggle carrying which one it is pointed at.

## Settings

The dropdown is the third kind of control this tab draws, and adding it put `settingsTab.ts` past the seven-entity limit the architecture test enforces. It splits along the line it was already holding: `controls.ts` is the list of settings there are, `settingsTab.ts` is the two ways Obsidian gets them. Both paths read the one list, so neither can describe a setting the other does not have.

That split also paid for extracting `draw()` out of `display()`. A control per kind, each a chain inside a callback inside a branch inside a loop, had `display()` at a cognitive score of 32 with the dropdown added, and 18 without it. It is 1 now, and `settings/` reports no smells.

A stored setting is whatever the file held, so the dropdown checks a written value against its own options rather than against a second list that could drift from them.

## Worth knowing

`root` has no command of its own. It is reachable by pointing the toggle at it, but there is no "Make current line a top-level heading" in the palette. The icon record is kept whole so that the day it earns one, the symbol is already chosen rather than picked in a hurry.

The command name does not say the target — it stays "Toggle heading on current line" rather than "… (child level)". Embedding it would mean duplicating the dropdown's wording inside `commands/`, which deliberately never imports `settings/`.

## Tests

477 pass; lint and `tsc` clean. Coverage includes the toggle through every layer, all three targets end to end, that the target is read at press time rather than registration, and that a value which is not one of the three is refused rather than stored.