### PR TITLE
Leave the caret where the heading is about to be typed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,10 @@ than leaving each caller to work them out.
 - **`core/`** is the whole adjustment as a function of text. No Obsidian
   import anywhere in it, which is what makes the behaviour testable directly.
 - **`editor/`** is the Obsidian adapter, and the only place a decision becomes
-  an effect: one undoable transaction and one `Notice`.
+  an effect: one undoable transaction, one `Notice`, and where the caret is
+  left. The caret is this layer's business alone — `core/` returns edits and
+  has no idea anyone is looking at the file — and it is set inside the same
+  transaction, so putting it right costs no second undo step.
 - **`settings/`** is the policy — defaults, how a stored value is read back,
   how a default is chosen — with the dialog that edits it behind the door.
   `controls.ts` is the list of settings there are; `settingsTab.ts` is the two

--- a/src/editor/editorDocument.ts
+++ b/src/editor/editorDocument.ts
@@ -1,5 +1,5 @@
 // Types only: this module must stay loadable — and testable — without Obsidian.
-import type { Editor, EditorChange } from 'obsidian';
+import type { Editor, EditorChange, EditorRangeOrCaret } from 'obsidian';
 
 /**
  * An Obsidian editor, seen as plain lines.
@@ -57,8 +57,18 @@ export function selectedLineRange(editor: Editor): LineRange | null {
   };
 }
 
-/** Writes the edits back as a single undoable transaction. */
-export function applyLineEdits(editor: Editor, edits: readonly LineEdit[]): void {
+/**
+ * Writes the edits back as a single undoable transaction.
+ *
+ * @param caretLine A line the caret is to be kept on the text of. Left out by
+ *   the commands that rewrite a whole document or a selection, where the caret
+ *   is not what the user is looking at.
+ */
+export function applyLineEdits(
+  editor: Editor,
+  edits: readonly LineEdit[],
+  caretLine?: number
+): void {
   if (edits.length === 0) {
     return;
   }
@@ -69,5 +79,38 @@ export function applyLineEdits(editor: Editor, edits: readonly LineEdit[]): void
     text: edit.text,
   }));
 
-  editor.transaction({ changes });
+  // Sent only when there is one to send: a document-wide rewrite has no caret
+  // to speak for, and saying so with an empty key is not the same as staying
+  // out of the way.
+  const caret = caretLine === undefined ? undefined : caretOn(editor, edits, caretLine);
+
+  editor.transaction(caret ? { changes, selection: caret } : { changes });
+}
+
+/**
+ * Where the caret belongs once the opening of its line has been rewritten.
+ *
+ * An editor left to itself keeps a caret sitting exactly where text was
+ * inserted *in front of* that text, which is right for typing and wrong here: a
+ * caret at the head of the line is a caret waiting to write the heading, not one
+ * asking to be pushed behind the `#`. It is only ever visible on a line with
+ * nothing on it, because there the caret has nowhere else to be.
+ *
+ * So the caret moves with the line's content, and never lands before what was
+ * just written.
+ */
+function caretOn(
+  editor: Editor,
+  edits: readonly LineEdit[],
+  line: number
+): EditorRangeOrCaret | undefined {
+  const edit = edits.find((each) => each.line === line);
+  if (!edit) {
+    return undefined;
+  }
+
+  const { ch } = editor.getCursor();
+  const carried = ch + edit.text.length - (edit.toColumn - edit.fromColumn);
+
+  return { from: { line, ch: Math.max(carried, edit.fromColumn + edit.text.length) } };
 }

--- a/src/editor/headingAdjustmentService.ts
+++ b/src/editor/headingAdjustmentService.ts
@@ -76,7 +76,8 @@ export function adjustEditorLine(
       fromLine: line,
       toLine: line,
       levelZero: true,
-    })
+    }),
+    line
   );
 }
 
@@ -93,20 +94,27 @@ export function placeEditorLine(
   placement: LinePlacement,
   target: HeadingPlacement
 ): void {
+  const line = cursorLine(editor);
+
   applyOutcome(
     editor,
-    placeLineHeading(readEditorLines(editor), cursorLine(editor), placement, target)
+    placeLineHeading(readEditorLines(editor), line, placement, target),
+    line
   );
 }
 
 /** Writes what was decided, then says what happened — the two effects, in order. */
-function applyOutcome(editor: Editor, outcome: AdjustmentOutcome): void {
+function applyOutcome(
+  editor: Editor,
+  outcome: AdjustmentOutcome,
+  caretLine?: number
+): void {
   if (outcome.status === 'rejected') {
     reportRejection(outcome.reason);
     return;
   }
 
-  applyLineEdits(editor, outcome.edits);
+  applyLineEdits(editor, outcome.edits, caretLine);
   reportAdjusted(outcome.changedCount, outcome.truncatedSections);
 }
 

--- a/tests/editor/editorDocument.test.ts
+++ b/tests/editor/editorDocument.test.ts
@@ -11,15 +11,16 @@ import {
  * The slice of Obsidian's Editor this layer actually uses, stubbed. Anything
  * these tests do not implement is something the adapter must not reach for.
  */
-function fakeEditor(lines: string[], selections: unknown[] = []) {
-  const transactions: unknown[] = [];
+function fakeEditor(lines: string[], selections: unknown[] = [], cursor = { line: 0, ch: 0 }) {
+  const transactions: Array<{ selection?: { from: { line: number; ch: number } } }> = [];
 
   return {
     transactions,
     lineCount: () => lines.length,
     getLine: (index: number) => lines[index],
+    getCursor: () => cursor,
     listSelections: () => selections,
-    transaction: (spec: unknown) => transactions.push(spec),
+    transaction: (spec: never) => transactions.push(spec),
   };
 }
 
@@ -102,5 +103,72 @@ describe('applyLineEdits', () => {
     applyLineEdits(asEditor(editor), []);
 
     assert.deepEqual(editor.transactions, []);
+  });
+});
+
+/**
+ * Where a caret is left when the opening of its line is rewritten.
+ *
+ * An editor left to itself keeps a caret sitting exactly at an insertion in
+ * front of what was inserted. That is right for typing and wrong for markup: a
+ * caret at the head of a line is one waiting to write the heading, not one
+ * asking to be pushed behind the `#`.
+ */
+describe('the caret applyLineEdits asks for', () => {
+  /** The caret a transaction asked for, or null when it asked for none. */
+  function caret(editor: ReturnType<typeof fakeEditor>) {
+    return editor.transactions[0]?.selection?.from ?? null;
+  }
+
+  const write = (text: string, toColumn = 0) => [
+    { line: 1, fromColumn: 0, toColumn, text },
+  ];
+
+  test('lands past what was written when the caret was at the head of the line', () => {
+    const editor = fakeEditor([], [], { line: 1, ch: 0 });
+
+    applyLineEdits(asEditor(editor), write('## '), 1);
+
+    assert.deepEqual(caret(editor), { line: 1, ch: 3 });
+  });
+
+  test('carries the caret along by however much the opening grew', () => {
+    const editor = fakeEditor([], [], { line: 1, ch: 5 });
+
+    applyLineEdits(asEditor(editor), write('## '), 1);
+
+    assert.deepEqual(caret(editor), { line: 1, ch: 8 });
+  });
+
+  test('carries it back by however much the opening shrank', () => {
+    const editor = fakeEditor([], [], { line: 1, ch: 6 });
+
+    applyLineEdits(asEditor(editor), write('', 3), 1);
+
+    assert.deepEqual(caret(editor), { line: 1, ch: 3 });
+  });
+
+  test('a caret inside the markup being removed comes out at the text', () => {
+    const editor = fakeEditor([], [], { line: 1, ch: 1 });
+
+    applyLineEdits(asEditor(editor), write('', 3), 1);
+
+    assert.deepEqual(caret(editor), { line: 1, ch: 0 });
+  });
+
+  test('asks for nothing when no caret line is named', () => {
+    const editor = fakeEditor([], [], { line: 1, ch: 0 });
+
+    applyLineEdits(asEditor(editor), write('## '));
+
+    assert.equal(caret(editor), null);
+  });
+
+  test('asks for nothing when the named line is not one being edited', () => {
+    const editor = fakeEditor([], [], { line: 4, ch: 0 });
+
+    applyLineEdits(asEditor(editor), write('## '), 4);
+
+    assert.equal(caret(editor), null);
   });
 });

--- a/tests/editor/headingAdjustmentService.test.ts
+++ b/tests/editor/headingAdjustmentService.test.ts
@@ -15,17 +15,27 @@ import {
  */
 
 /** The slice of Obsidian's Editor this layer uses, and a record of what it wrote. */
-function fakeEditor(lines: string[], cursor = 0) {
-  const transactions: Array<{ changes: EditorChange[] }> = [];
+function fakeEditor(lines: string[], cursor = 0, ch = 0) {
+  const transactions: Array<Transaction> = [];
 
   return {
     transactions,
     lineCount: () => lines.length,
     getLine: (index: number) => lines[index],
-    getCursor: () => ({ line: cursor, ch: 0 }),
+    getCursor: () => ({ line: cursor, ch }),
     listSelections: () => [],
-    transaction: (spec: { changes: EditorChange[] }) => transactions.push(spec),
+    transaction: (spec: Transaction) => transactions.push(spec),
   };
+}
+
+interface Transaction {
+  changes: EditorChange[];
+  selection?: { from: { line: number; ch: number } };
+}
+
+/** Where the recorded transaction leaves the caret, or null if it says nothing. */
+function caret(editor: ReturnType<typeof fakeEditor>) {
+  return editor.transactions[0]?.selection?.from ?? null;
 }
 
 interface EditorChange {
@@ -42,7 +52,7 @@ const asEditor = (editor: ReturnType<typeof fakeEditor>) => editor as any;
 function written(editor: ReturnType<typeof fakeEditor>, before: string[]): string {
   const lines = [...before];
 
-  for (const change of editor.transactions.flatMap((spec) => spec.changes)) {
+  for (const change of editor.transactions.flatMap((spec: Transaction) => spec.changes)) {
     const line = lines[change.from.line];
     lines[change.from.line] =
       line.slice(0, change.from.ch) + change.text + line.slice(change.to.ch);
@@ -215,5 +225,72 @@ describe('a placement reads the cursor too', () => {
     placeEditorLine(asEditor(editor), 'child', 'sibling');
 
     assert.deepEqual(editor.transactions, []);
+  });
+});
+
+/**
+ * Where the caret is left, which is only ever noticed on an empty line.
+ *
+ * An editor left to itself keeps a caret sitting exactly where text was
+ * inserted in front of that text. On a line with something on it the caret is
+ * almost never at column zero, so it rides along and nobody sees this; on an
+ * empty line column zero is the only place it can be, so every insertion lands
+ * behind it.
+ */
+describe('the caret after writing a heading onto the current line', () => {
+  test('waits after the hash on an empty line, ready to be typed into', () => {
+    const editor = fakeEditor(['## Setup', ''], 1, 0);
+
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+
+    assert.equal(written(editor, ['## Setup', '']), '## Setup\n## ');
+    assert.deepEqual(caret(editor), { line: 1, ch: 3 });
+  });
+
+  test('stays with its text on a line that has some', () => {
+    const editor = fakeEditor(['## Setup', 'some prose'], 1, 5);
+
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+
+    // `some |prose` before, `## some |prose` after: the same character.
+    assert.deepEqual(caret(editor), { line: 1, ch: 8 });
+  });
+
+  test('is not pushed behind the markup when it sits at the head of the line', () => {
+    const editor = fakeEditor(['## Setup', 'some prose'], 1, 0);
+
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+
+    assert.deepEqual(caret(editor), { line: 1, ch: 3 });
+  });
+
+  test('comes back with the text when the heading is taken off', () => {
+    const editor = fakeEditor(['## Setup', '## some prose'], 1, 6);
+
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+
+    // `## som|e prose` before, `som|e prose` after.
+    assert.equal(written(editor, ['## Setup', '## some prose']), '## Setup\nsome prose');
+    assert.deepEqual(caret(editor), { line: 1, ch: 3 });
+  });
+
+  test('shifting the current line moves it too', () => {
+    const editor = fakeEditor([''], 0, 0);
+
+    adjustEditorLine(asEditor(editor), 'increase', 1);
+
+    assert.equal(written(editor, ['']), '# ');
+    assert.deepEqual(caret(editor), { line: 0, ch: 2 });
+  });
+
+  test('a document-wide adjustment leaves the caret to the editor', () => {
+    const editor = fakeEditor(['# A', '## B'], 0, 0);
+
+    adjustEditorHeadings(asEditor(editor), 'increase', 1, {
+      headingsToBullets: false,
+      bulletsToHeadings: false,
+    });
+
+    assert.equal(caret(editor), null);
   });
 });


### PR DESCRIPTION
Fixes #10.

Writing a heading onto an empty line put the caret behind the hash, so the next keystroke landed in front of the markup instead of after it.

## It was not about empty lines

It was reported as the caret being respected on lines with text but not on empty ones. That is the symptom rather than the rule — the caret was never being moved at all.

An editor left to itself keeps a caret sitting exactly at an insertion *in front of* what was inserted. That is right for typing and wrong for markup. On a line with something on it the caret is almost never at column zero, so it rides along and nobody sees this. On an empty line column zero is the only place it can be, so every insertion lands behind it.

The same thing happened on a line **with** text whenever the caret sat at the very start of it — just far less reliably, which is why it read as an empty-line problem.

## The rule

The caret moves with the line's content and never lands before what was just written. One rule covers both halves: a heading written onto a line puts the caret where the text goes, and a heading taken off brings it back with the text it was in.

| Before (caret as `\|`) | After |
| --- | --- |
| `\|` (empty line) | `## \|` |
| `\|some prose` | `## \|some prose` |
| `some \|prose` | `## some \|prose` — the same character |
| `## som\|e prose` | `som\|e prose` |
| `- \|item` | `## \|item` |

It is set inside the same transaction as the edits, so undo is still one keystroke and nothing about it is a second step.

## Scope

Only the current-line commands ask for a caret. A document-wide or selection rewrite sends exactly the transaction it sent before, down to not carrying the key at all — the caret is not what a user is looking at while a whole note is being rewritten, and saying nothing is not the same as saying nothing in particular. There is a test asserting that.

## Tests

490 pass; lint and `tsc` clean. Six tests on `applyLineEdits` directly, covering the caret at the head of a line, carried forward, carried back, inside markup being removed, no caret line named, and a caret line nothing edits. Six more through the service, including the reported case and the document-wide one that must stay untouched.

Reasoned from `EditorTransaction.selection` rather than observed in a running vault, so worth a look on a device before it ships.