### PR TITLE
Carry nested content across the heading / list-item line

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ line back in a list, either on its own or carrying the section the heading held:
 | A list item, with the section nested under it | `- D` / `  - E` |
 
 The section ends where the heading's does — at the next heading, whatever its
-level.
+level. It moves as one block, so its own nesting is untouched, and it moves by
+one level in whatever the section already indents by: a tab-nested list gets a
+tab, a four-space one gets four spaces. A section with no nesting to go on
+takes the width of the marker instead.
 
 The round trip does not close on depth: a heading remembers nothing about how
 far the item it came from was indented, so an item lifted out of four levels of

--- a/README.md
+++ b/README.md
@@ -206,6 +206,55 @@ definition of a list item across every command. Removing a heading never writes
 a bullet back, either — Markdown records no provenance for the marker it
 replaced, so there is nothing to restore.
 
+### Crossing between a heading and a list item
+
+A list item holds whatever is indented past it; a heading holds whatever follows
+it until the next heading. They disagree about what sits underneath, so a line
+that stops being one and starts being the other leaves its content answering to
+nothing.
+
+**Turning a list item into a heading** — with "Toggle heading", "Sibling of the
+heading above" or "Child of the heading above" — brings the items nested under
+it along, by as much as the item itself lost:
+
+```markdown
+- A                    - A
+  - B                    - B
+    - C                    - C
+      - D    ← caret    # D
+        - E              - E
+          - etc            - etc
+```
+
+Left where they were, those children sit at an indent nothing encloses any
+more — which CommonMark reads as a code block rather than a list. **Bring nested
+list items along** is on by default for that reason; switch it off to write only
+the line the caret is on.
+
+The block ends at the first line indented no further than the item itself, so a
+sibling further down and everything under it stay put. A blank line does not end
+it. A line that is not a list item has nothing nested to carry, so a paragraph
+turned into a heading is written on its own.
+
+**Removing a heading** goes the other way, and ships doing what it always did:
+writing the text on its own. **Removing a heading leaves** can instead put the
+line back in a list, either on its own or carrying the section the heading held:
+
+| Setting | `# D` followed by `- E` becomes |
+| --- | --- |
+| Plain text *(default)* | `D` / `- E` |
+| A list item | `- D` / `- E` |
+| A list item, with the section nested under it | `- D` / `  - E` |
+
+The section ends where the heading's does — at the next heading, whatever its
+level.
+
+The round trip does not close on depth: a heading remembers nothing about how
+far the item it came from was indented, so an item lifted out of four levels of
+nesting comes back at the top level. Markdown records no provenance for that,
+which is the same limit [ADR-0001](docs/adr/0001-bullet-to-heading-reversal-is-marker-blind-and-opt-in.md)
+describes.
+
 ### The custom range
 
 The five other scopes each name their range in their own command name, which is
@@ -253,6 +302,13 @@ conversion**:
 - **Toggle puts the heading at**: Which level "Toggle heading on current line"
   writes, and so which level it takes back off — the top level (`#`), the same
   level as the heading above, or one below it. Defaults to the same level.
+- **Bring nested list items along**: When a placement turns a list item into a
+  heading, move the items nested under it out by as much as it lost. On by
+  default — see [Crossing between a heading and a list
+  item](#crossing-between-a-heading-and-a-list-item).
+- **Removing a heading leaves**: What "Remove heading from current line", and a
+  toggle switching one off, writes in its place — plain text (the default), a
+  list item, or a list item with the heading's section nested under it.
 - **Custom range: top**: Where the two "custom range" commands start — the top
   of the note, or the cursor line. See [The custom range](#the-custom-range).
 - **Custom range: bottom**: Where the same two commands stop — the cursor line,

--- a/src/commands/adjustmentCommands.ts
+++ b/src/commands/adjustmentCommands.ts
@@ -140,7 +140,7 @@ export function placeCurrentLine(
   if (editor) {
     // Asked for now rather than when the command was registered, so a setting
     // changed mid-session takes effect without a reload.
-    placeEditorLine(editor, placement, context.toggleTarget());
+    placeEditorLine(editor, placement, context.toggleTarget(), context.conversion());
   }
 }
 

--- a/src/contracts.d.ts
+++ b/src/contracts.d.ts
@@ -64,6 +64,24 @@ export interface ConversionSettings {
   /** On decrease, turn list items back into headings. See docs/adr/0001. */
   bulletsToHeadings: boolean;
   /**
+   * When a placement writes a heading onto a list item, lift the items nested
+   * under it by as much as the item itself lost.
+   *
+   * Without it a deeply nested item leaves its children behind at their old
+   * indent, under a heading that no longer encloses them — which CommonMark
+   * reads as an indented code block rather than a list.
+   */
+  liftNestedOnHeading?: boolean;
+  /**
+   * What a placement writes where a heading used to be.
+   *
+   * `plain` is the text on its own. The other two put the line back in a list,
+   * and `bullet-with-section` carries the heading's section in with it, so the
+   * lines the heading held become the item's children rather than its
+   * siblings.
+   */
+  removeHeadingAs?: 'plain' | 'bullet' | 'bullet-with-section';
+  /**
    * The deepest level a heading may occupy before it converts to a bullet, and
    * the level a bullet converts back to. Markdown's own limit of six when
    * omitted, which is the setting doing nothing.

--- a/src/core/adjustHeadings.ts
+++ b/src/core/adjustHeadings.ts
@@ -121,11 +121,12 @@ export function placeLineHeading(
   lines: readonly string[],
   lineNumber: number,
   placement: LinePlacement,
-  target: HeadingPlacement = 'sibling'
+  target: HeadingPlacement = 'sibling',
+  conversion?: ConversionSettings
 ): AdjustmentOutcome {
   const fenced = computeFencedLines(lines);
   const above = parseHeadings(lines, 0, lineNumber - 1, fenced);
-  const edits = placeLineLevel(lines, fenced, lineNumber, placement, above, target);
+  const edits = placeLineLevel(lines, fenced, lineNumber, placement, above, target, conversion);
 
   return { status: 'adjusted', edits, changedCount: edits.length, truncatedSections: 0 };
 }

--- a/src/core/line/line.ts
+++ b/src/core/line/line.ts
@@ -1,10 +1,12 @@
 import type {
   AdjustmentOperation,
+  ConversionSettings,
   HeadingPlacement,
   LinePlacement,
 } from '../../contracts';
 import type { LeveledLine } from './placement';
 import { enclosingLevel, placedLevel } from './placement';
+import { indentSectionEdits, liftNestedEdits } from './nesting';
 import { listMarkerWidth } from './marker';
 
 /**
@@ -75,10 +77,19 @@ export function adjustLineLevel(
  * line whether it is already there, and is why the level goes to `placedLevel`
  * rather than being settled before `writeLine` is called.
  *
+ * Placing is also the only scope that may touch a line other than its own, and
+ * `nesting.ts` says why: a list item and a heading disagree about what sits
+ * under them, so a line crossing between the two leaves its content behind
+ * unless the content comes too. Which way it moves is read off the edit rather
+ * than worked out twice — the text written is the line's new opening, and a
+ * `#` there is the whole of what distinguishes the two directions.
+ *
  * @param above The headings preceding the line, nearest last. The last of them
  *   is the enclosing heading, and the whole of what a placement reads.
  * @param target Where a toggle is pointed, which the user chooses. Ignored by
  *   every other placement.
+ * @param conversion Whether the content under the line travels with it, and
+ *   what a removed heading leaves behind. Neither applies when omitted.
  */
 export function placeLineLevel(
   lines: readonly string[],
@@ -86,12 +97,38 @@ export function placeLineLevel(
   lineNumber: number,
   placement: LinePlacement,
   above: readonly LeveledLine[],
-  target: HeadingPlacement
+  target: HeadingPlacement,
+  conversion?: ConversionSettings
 ): LineLevelEdit[] {
   const enclosing = enclosingLevel(above);
-  return writeLine(lines, fenced, lineNumber, (level) =>
-    placedLevel(placement, enclosing, level, target)
+  const removeAs = conversion?.removeHeadingAs ?? 'plain';
+  const edits = writeLine(
+    lines,
+    fenced,
+    lineNumber,
+    (level) => placedLevel(placement, enclosing, level, target),
+    removeAs
   );
+
+  const opening = edits[0]?.text;
+  if (opening === undefined) {
+    return edits;
+  }
+
+  const line = lines[lineNumber] ?? '';
+
+  // Became a heading: whatever the line was holding as a list item is now
+  // indented under something that no longer encloses it.
+  if (opening.startsWith('#')) {
+    return conversion?.liftNestedOnHeading && listMarkerWidth(line) > 0
+      ? [...edits, ...liftNestedEdits(lines, lineNumber, line.length - line.trimStart().length)]
+      : edits;
+  }
+
+  // Became a list item: the section the heading held becomes its content.
+  return removeAs === 'bullet-with-section'
+    ? [...edits, ...indentSectionEdits(lines, fenced, lineNumber, opening.length)]
+    : edits;
 }
 
 /**
@@ -109,7 +146,8 @@ function writeLine(
   lines: readonly string[],
   fenced: readonly boolean[],
   lineNumber: number,
-  choose: (level: number) => number
+  choose: (level: number) => number,
+  removeAs: 'plain' | 'bullet' | 'bullet-with-section' = 'plain'
 ): LineLevelEdit[] {
   // A `#` inside a fence is text, and so is everything beside it: a line the
   // document reads as code is not one to write a heading onto.
@@ -130,7 +168,7 @@ function writeLine(
   // `#`s and their gap, or the marker of a list item at level zero.
   const written = match ? match[0].length : listMarkerWidth(line);
 
-  return [prefixEdit(lineNumber, level, written, target)];
+  return [prefixEdit(lineNumber, level, written, target, removeAs)];
 }
 
 /**
@@ -144,12 +182,15 @@ function prefixEdit(
   lineNumber: number,
   level: number,
   written: number,
-  target: number
+  target: number,
+  removeAs: 'plain' | 'bullet' | 'bullet-with-section'
 ): LineLevelEdit {
-  // Down to plain text: the gap goes with the `#`s, or the line keeps a space
-  // it never asked for.
+  // Down out of a heading: the gap goes with the `#`s, or the line keeps a
+  // space it never asked for. What replaces them is the user's choice — nothing
+  // at all, or the marker that puts the line back in a list.
   if (target === 0) {
-    return { line: lineNumber, fromColumn: 0, toColumn: written, text: '' };
+    const opening = removeAs === 'plain' ? '' : '- ';
+    return { line: lineNumber, fromColumn: 0, toColumn: written, text: opening };
   }
 
   // Up from plain text: the gap has to be written, and a list marker is an

--- a/src/core/line/nesting.ts
+++ b/src/core/line/nesting.ts
@@ -1,0 +1,121 @@
+/**
+ * What sits underneath one line, and the edits that move it along with the
+ * line's own opening.
+ *
+ * The current-line scope consults nothing above or below itself — that is what
+ * makes it the finest scope the plugin has. Crossing between a heading and a
+ * list item is the one exception, and only because the two disagree about what
+ * "underneath" means: a list item holds what is indented past it, a heading
+ * holds everything until the next heading. A line that stops being one and
+ * starts being the other leaves whatever it held answering to nothing, so the
+ * content has to move with it or the markup stops saying what the document
+ * shows.
+ *
+ * A leaf: `line.ts` decides whether either of these applies, because deciding
+ * needs the level the line is about to be written at and that is `line.ts`'s
+ * to know.
+ */
+
+/** A replacement of one span of one line. `LineLevelEdit` satisfies this. */
+export interface NestingEdit {
+  line: number;
+  fromColumn: number;
+  toColumn: number;
+  text: string;
+}
+
+/**
+ * A heading's opening, restated rather than imported.
+ *
+ * `line.ts` matches the same syntax to read the level it is about to change;
+ * here only the fact of a heading matters, because a heading is where the
+ * section being carried stops. Naming its pattern across would point an arrow
+ * back at the file that imports this one.
+ */
+const HEADING_LINE = /^#{1,6}\s/;
+
+/** The whitespace a line opens with, in columns. */
+function leadingWidth(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+/**
+ * Moves the items nested under a list item out by as much as the item lost when
+ * it became a heading.
+ *
+ * The shift is the first nested line's own indent, not a computed unit: taking
+ * the depth the document actually wrote means the children land at column zero
+ * and everything below keeps its spacing relative to them, whether the list is
+ * indented with tabs, two spaces or four.
+ *
+ * The nested block runs to the first non-blank line indented no further than
+ * the item itself. Blank lines do not end it — a list with a gap in it is still
+ * one list — and a fenced block inside it moves with the rest, because it was
+ * indented as part of the item and is still part of it afterwards.
+ *
+ * @param indent The converted line's own indent, in columns.
+ */
+export function liftNestedEdits(
+  lines: readonly string[],
+  lineNumber: number,
+  indent: number
+): NestingEdit[] {
+  const edits: NestingEdit[] = [];
+  let shift = 0;
+
+  for (let line = lineNumber + 1; line < lines.length; line++) {
+    const text = lines[line];
+    if (text.trim() === '') {
+      continue;
+    }
+
+    const leading = leadingWidth(text);
+    if (leading <= indent) {
+      break;
+    }
+
+    // The first line under the item sets how far the whole block moves, so the
+    // block keeps its own shape and only stops being nested in the item.
+    if (shift === 0) {
+      shift = leading;
+    }
+
+    edits.push({ line, fromColumn: 0, toColumn: Math.min(shift, leading), text: '' });
+  }
+
+  return edits;
+}
+
+/**
+ * Indents the lines a heading held, so they become the content of the list item
+ * written in its place.
+ *
+ * The section ends where the heading's own does: at the next heading, whatever
+ * its level, or at the end of the note. A `#` inside a code fence is text and
+ * does not end anything.
+ *
+ * @param width How far to indent — the width of the marker now opening the line.
+ */
+export function indentSectionEdits(
+  lines: readonly string[],
+  fenced: readonly boolean[],
+  lineNumber: number,
+  width: number
+): NestingEdit[] {
+  const edits: NestingEdit[] = [];
+  const padding = ' '.repeat(width);
+
+  for (let line = lineNumber + 1; line < lines.length; line++) {
+    const text = lines[line];
+    if (!fenced[line] && HEADING_LINE.test(text)) {
+      break;
+    }
+    if (text.trim() === '') {
+      continue;
+    }
+
+    edits.push({ line, fromColumn: 0, toColumn: 0, text: padding });
+  }
+
+  return edits;
+}

--- a/src/core/line/nesting.ts
+++ b/src/core/line/nesting.ts
@@ -94,7 +94,17 @@ export function liftNestedEdits(
  * its level, or at the end of the note. A `#` inside a code fence is text and
  * does not end anything.
  *
- * @param width How far to indent — the width of the marker now opening the line.
+ * Every line takes the same prefix, which is what carries the section's own
+ * shape through unchanged — only its depth as a whole moves. What that prefix
+ * is matters as much as its width: padding a tab-indented list with spaces
+ * leaves `\t- child` written as `  \t- child`, two indent styles deep on one
+ * line, holding together only because a tab happens to land on the column the
+ * parent's text starts at. So the section is asked what a level looks like in
+ * this document and given one more of those, falling back to the marker's own
+ * width when it has no nesting to answer with.
+ *
+ * @param width How wide a level is when the section has no indent of its own —
+ *   the width of the marker now opening the line.
  */
 export function indentSectionEdits(
   lines: readonly string[],
@@ -102,20 +112,52 @@ export function indentSectionEdits(
   lineNumber: number,
   width: number
 ): NestingEdit[] {
-  const edits: NestingEdit[] = [];
-  const padding = ' '.repeat(width);
+  const section = sectionLines(lines, fenced, lineNumber);
+  const padding = indentUnit(lines, section) ?? ' '.repeat(width);
+
+  return section.map((line) => ({ line, fromColumn: 0, toColumn: 0, text: padding }));
+}
+
+/** The non-blank lines the heading at `lineNumber` holds, in document order. */
+function sectionLines(
+  lines: readonly string[],
+  fenced: readonly boolean[],
+  lineNumber: number
+): number[] {
+  const held: number[] = [];
 
   for (let line = lineNumber + 1; line < lines.length; line++) {
     const text = lines[line];
     if (!fenced[line] && HEADING_LINE.test(text)) {
       break;
     }
-    if (text.trim() === '') {
-      continue;
+    if (text.trim() !== '') {
+      held.push(line);
     }
-
-    edits.push({ line, fromColumn: 0, toColumn: 0, text: padding });
   }
 
-  return edits;
+  return held;
+}
+
+/**
+ * One level of nesting as this section writes it, or nothing when it is flat.
+ *
+ * The narrowest indent in the section rather than the first, because the first
+ * line under a heading can already be nested several levels deep while the
+ * narrowest is a single step by definition. Taken verbatim: a tab and four
+ * spaces are each one level, and which one this document means is not something
+ * to infer from a column count.
+ */
+function indentUnit(lines: readonly string[], section: readonly number[]): string | undefined {
+  let unit: string | undefined;
+
+  for (const line of section) {
+    const text = lines[line];
+    const indent = text.slice(0, leadingWidth(text));
+    if (indent !== '' && (unit === undefined || indent.length < unit.length)) {
+      unit = indent;
+    }
+  }
+
+  return unit;
 }

--- a/src/editor/headingAdjustmentService.ts
+++ b/src/editor/headingAdjustmentService.ts
@@ -93,13 +93,14 @@ export function adjustEditorLine(
 export function placeEditorLine(
   editor: Editor,
   placement: LinePlacement,
-  target: HeadingPlacement
+  target: HeadingPlacement,
+  conversion: ConversionSettings
 ): void {
   const line = cursorLine(editor);
 
   applyOutcome(
     editor,
-    placeLineHeading(readEditorLines(editor), line, placement, target),
+    placeLineHeading(readEditorLines(editor), line, placement, target, conversion),
     line
   );
 }

--- a/src/settings/controls.ts
+++ b/src/settings/controls.ts
@@ -33,7 +33,7 @@ const RANGE = {
 type LevelKey = 'increaseLevel' | 'decreaseLevel' | 'deepestHeadingLevel';
 
 /** The settings a toggle can be bound to. */
-type ToggleKey = 'headingsToBullets' | 'bulletsToHeadings';
+type ToggleKey = 'headingsToBullets' | 'bulletsToHeadings' | 'liftNestedOnHeading';
 
 /**
  * Every dropdown's options, in the user's words, keyed by the setting they
@@ -59,6 +59,11 @@ export const OPTIONS = {
     cursor: 'Cursor line',
     'note-end': 'End of the note',
   } satisfies Record<HeadingAdjusterSettings['customRangeBottom'], string>,
+  removeHeadingAs: {
+    plain: 'Plain text',
+    bullet: 'A list item',
+    'bullet-with-section': 'A list item, with the section nested under it',
+  } satisfies Record<NonNullable<HeadingAdjusterSettings['removeHeadingAs']>, string>,
 };
 
 /**
@@ -129,7 +134,7 @@ export const SETTINGS: SettingSection[] = [
     ],
   },
   {
-    heading: 'Toggle heading on current line',
+    heading: 'Placing a heading on the current line',
     items: [
       {
         name: 'Toggle puts the heading at',
@@ -140,6 +145,26 @@ export const SETTINGS: SettingSection[] = [
           type: 'dropdown',
           key: 'toggleTarget',
           options: OPTIONS.toggleTarget,
+        },
+      },
+      {
+        name: 'Bring nested list items along',
+        desc: 'When "Toggle heading", "Sibling of the heading above" or "Child of the '
+          + 'heading above" turns a list item into a heading, move the items nested '
+          + 'under it out by as much as it lost. Without this they stay at their old '
+          + 'indent under a heading that no longer encloses them.',
+        control: { type: 'toggle', key: 'liftNestedOnHeading' },
+      },
+      {
+        name: 'Removing a heading leaves',
+        desc: 'What "Remove heading from current line" — and a toggle switching one '
+          + 'off — writes in its place. The last option also indents the lines the '
+          + 'heading held, so they become the new item\'s content rather than its '
+          + 'siblings.',
+        control: {
+          type: 'dropdown',
+          key: 'removeHeadingAs',
+          options: OPTIONS.removeHeadingAs,
         },
       },
     ],

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -26,6 +26,12 @@ const DEFAULT_SETTINGS: HeadingAdjusterSettings = {
   // What the toggle did before it could be pointed anywhere else, so an
   // upgrade finds the command behaving exactly as it left it.
   toggleTarget: 'sibling',
+  // On: a heading that leaves its children stranded at an indent nothing
+  // encloses is broken markup, not a preference.
+  liftNestedOnHeading: true,
+  // What removing a heading has always written, so the command keeps meaning
+  // what its name says until the user asks for something else.
+  removeHeadingAs: 'plain',
   // The whole note, so the custom commands start out as a second copy of the
   // document commands rather than as something surprising.
   customRangeTop: 'note-start',

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -92,6 +92,11 @@ export class HeadingAdjusterSettingTab extends PluginSettingTab {
    * rather than read. `store` is shared: the three components hand back three
    * different types and `setControlValue` is what decides which are real, so
    * there is nothing per-kind to say here.
+   *
+   * Two settings read back optional, because core takes them through the narrow
+   * `ConversionSettings` where they may be left out. `readSettings` fills every
+   * key from the defaults, so the fallbacks below never fire in the app — they
+   * are what lets the types say that without a cast.
    */
   private draw(setting: Setting, control: ControlDefinition['control']): void {
     const store = (value: unknown) => void this.setControlValue(control.key, value);
@@ -111,14 +116,14 @@ export class HeadingAdjusterSettingTab extends PluginSettingTab {
       setting.addDropdown((dropdown) =>
         dropdown
           .addOptions(control.options)
-          .setValue(this.host.settings[control.key])
+          .setValue(this.host.settings[control.key] ?? Object.keys(control.options)[0])
           .onChange(store)
       );
       return;
     }
 
     setting.addToggle((toggle) =>
-      toggle.setValue(this.host.settings[control.key]).onChange(store)
+      toggle.setValue(this.host.settings[control.key] ?? false).onChange(store)
     );
   }
 }
@@ -147,6 +152,10 @@ function storeOption(
   }
   if (key === 'customRangeBottom' && value in OPTIONS.customRangeBottom) {
     settings.customRangeBottom = value as HeadingAdjusterSettings['customRangeBottom'];
+    return true;
+  }
+  if (key === 'removeHeadingAs' && value in OPTIONS.removeHeadingAs) {
+    settings.removeHeadingAs = value as HeadingAdjusterSettings['removeHeadingAs'];
     return true;
   }
   return false;

--- a/tests/commands/adjustmentCommands.test.ts
+++ b/tests/commands/adjustmentCommands.test.ts
@@ -374,3 +374,52 @@ describe('the custom-range commands', () => {
     assert.deepEqual(editor.transactions, []);
   });
 });
+
+describe('a placement command asks the plugin for the conversion', () => {
+  /**
+   * The same gap the rest of this file guards: `CommandContext` hands back
+   * answers rather than the settings object, so a placement that forgot to ask
+   * would compile and quietly do nothing about the content under the line.
+   */
+  test('the nested items move, which only happens if the setting arrived', () => {
+    const before = ['- A', '\t- B', '\t\t- C'];
+    const editor = fakeEditor([...before], [], 1);
+    const context = fakeContext(editor, {
+      headingsToBullets: false,
+      bulletsToHeadings: false,
+      liftNestedOnHeading: true,
+    });
+
+    placeCurrentLine(context, 'toggle');
+
+    assert.equal(written(editor, before), '- A\n# B\n- C');
+  });
+
+  test('with it switched off the same command writes only its own line', () => {
+    const before = ['- A', '\t- B', '\t\t- C'];
+    const editor = fakeEditor([...before], [], 1);
+    const context = fakeContext(editor, {
+      headingsToBullets: false,
+      bulletsToHeadings: false,
+      liftNestedOnHeading: false,
+    });
+
+    placeCurrentLine(context, 'toggle');
+
+    assert.equal(written(editor, before), '- A\n# B\n\t\t- C');
+  });
+
+  test('what a removed heading leaves comes from the plugin too', () => {
+    const before = ['# A', 'body'];
+    const editor = fakeEditor([...before], [], 0);
+    const context = fakeContext(editor, {
+      headingsToBullets: false,
+      bulletsToHeadings: false,
+      removeHeadingAs: 'bullet-with-section',
+    });
+
+    placeCurrentLine(context, 'plain');
+
+    assert.equal(written(editor, before), '- A\n  body');
+  });
+});

--- a/tests/core/line/line.test.ts
+++ b/tests/core/line/line.test.ts
@@ -347,4 +347,21 @@ describe('what a removed heading leaves behind', () => {
   test('a blank line inside the section is left blank rather than padded', () => {
     assert.deepEqual(removed(['# D', '', 'body'], SECTION), ['- D', '', '  body']);
   });
+
+  /**
+   * A `#` inside a fence is code, not a heading, so it does not end the section
+   * the item is taking with it.
+   */
+  test('a hash inside a code fence does not end the section', () => {
+    const lines = ['# D', '```', '# not a heading', '```', 'after'];
+    const fenced = [false, false, true, false, false];
+    const edits = placeLineLevel(lines, fenced, 0, 'plain', [], 'root', SECTION);
+    const next = [...lines];
+    for (const edit of edits) {
+      next[edit.line] =
+        next[edit.line].slice(0, edit.fromColumn) + edit.text + next[edit.line].slice(edit.toColumn);
+    }
+
+    assert.deepEqual(next, ['- D', '  ```', '  # not a heading', '  ```', '  after']);
+  });
 });

--- a/tests/core/line/line.test.ts
+++ b/tests/core/line/line.test.ts
@@ -225,3 +225,126 @@ describe('toggling a heading on and off the current line', () => {
     assert.deepEqual(placeLineLevel(['# A'], [true], 0, 'toggle', [], 'sibling'), []);
   });
 });
+
+describe('content travelling with a line that crosses between the two', () => {
+  /**
+   * The one thing the current-line scope reads beyond its own line, and only
+   * because a list item and a heading disagree about what sits under them: an
+   * item holds what is indented past it, a heading holds what follows it. A
+   * line crossing between the two leaves what it held answering to nothing.
+   */
+  const LIFT = { headingsToBullets: false, bulletsToHeadings: false, liftNestedOnHeading: true };
+  const OFF = { headingsToBullets: false, bulletsToHeadings: false, liftNestedOnHeading: false };
+
+  /** The document as the edits would leave it. */
+  function placed(
+    lines: string[],
+    lineNumber: number,
+    placement: LinePlacement,
+    conversion?: typeof LIFT
+  ): string[] {
+    const edits = placeLineLevel(lines, [], lineNumber, placement, [], 'root', conversion);
+    const next = [...lines];
+    for (const edit of edits) {
+      next[edit.line] =
+        next[edit.line].slice(0, edit.fromColumn) + edit.text + next[edit.line].slice(edit.toColumn);
+    }
+    return next;
+  }
+
+  const NESTED = ['- A', '\t- B', '\t\t- C', '\t\t\t- D', '\t\t\t\t- E', '\t\t\t\t\t- etc'];
+
+  test('the items under a converted list item come out with it', () => {
+    assert.deepEqual(placed(NESTED, 3, 'toggle', LIFT), [
+      '- A', '\t- B', '\t\t- C', '# D', '- E', '\t- etc',
+    ]);
+  });
+
+  test('switched off, they stay where they were', () => {
+    assert.deepEqual(placed(NESTED, 3, 'toggle', OFF), [
+      '- A', '\t- B', '\t\t- C', '# D', '\t\t\t\t- E', '\t\t\t\t\t- etc',
+    ]);
+  });
+
+  test('the sibling and child placements carry the nesting too', () => {
+    assert.deepEqual(placed(NESTED, 3, 'sibling', LIFT).slice(3), ['# D', '- E', '\t- etc']);
+    assert.deepEqual(placed(NESTED, 3, 'child', LIFT).slice(3), ['# D', '- E', '\t- etc']);
+  });
+
+  test('the block ends at the first line no deeper than the item', () => {
+    const lines = ['\t- D', '\t\t- E', '\t- sibling', '\t\t- its child'];
+
+    assert.deepEqual(placed(lines, 0, 'toggle', LIFT), [
+      '# D', '- E', '\t- sibling', '\t\t- its child',
+    ]);
+  });
+
+  test('a blank line does not end it — a list with a gap is still one list', () => {
+    const lines = ['- D', '\t- E', '', '\t- F'];
+
+    assert.deepEqual(placed(lines, 0, 'toggle', LIFT), ['# D', '- E', '', '- F']);
+  });
+
+  test('a line that is not a list item has nothing nested to carry', () => {
+    const lines = ['Some prose', '\t- E'];
+
+    assert.deepEqual(placed(lines, 0, 'toggle', LIFT), ['# Some prose', '\t- E']);
+  });
+
+  test('an item holding nothing is written on its own', () => {
+    assert.deepEqual(placed(['\t- D', '- after'], 0, 'toggle', LIFT), ['# D', '- after']);
+  });
+});
+
+describe('what a removed heading leaves behind', () => {
+  const PLAIN = { headingsToBullets: false, bulletsToHeadings: false, removeHeadingAs: 'plain' as const };
+  const BULLET = { headingsToBullets: false, bulletsToHeadings: false, removeHeadingAs: 'bullet' as const };
+  const SECTION = {
+    headingsToBullets: false,
+    bulletsToHeadings: false,
+    removeHeadingAs: 'bullet-with-section' as const,
+  };
+
+  function removed(lines: string[], conversion?: object): string[] {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const edits = placeLineLevel(lines, [], 0, 'plain', [], 'root', conversion as any);
+    const next = [...lines];
+    for (const edit of edits) {
+      next[edit.line] =
+        next[edit.line].slice(0, edit.fromColumn) + edit.text + next[edit.line].slice(edit.toColumn);
+    }
+    return next;
+  }
+
+  const SECTIONED = ['# D', '- E', '\t- etc', '# Next', '- untouched'];
+
+  test('plain text, which is what it always wrote', () => {
+    assert.deepEqual(removed(SECTIONED, PLAIN), ['D', '- E', '\t- etc', '# Next', '- untouched']);
+  });
+
+  test('the same with no conversion passed at all', () => {
+    assert.deepEqual(removed(SECTIONED), ['D', '- E', '\t- etc', '# Next', '- untouched']);
+  });
+
+  test('a list item, leaving what followed where it was', () => {
+    assert.deepEqual(removed(SECTIONED, BULLET), [
+      '- D', '- E', '\t- etc', '# Next', '- untouched',
+    ]);
+  });
+
+  test('a list item holding the section the heading held', () => {
+    assert.deepEqual(removed(SECTIONED, SECTION), [
+      '- D', '  - E', '  \t- etc', '# Next', '- untouched',
+    ]);
+  });
+
+  test('the section stops at the next heading, whatever its level', () => {
+    const lines = ['## D', 'body', '###### Deeper', 'after'];
+
+    assert.deepEqual(removed(lines, SECTION), ['- D', '  body', '###### Deeper', 'after']);
+  });
+
+  test('a blank line inside the section is left blank rather than padded', () => {
+    assert.deepEqual(removed(['# D', '', 'body'], SECTION), ['- D', '', '  body']);
+  });
+});

--- a/tests/core/line/line.test.ts
+++ b/tests/core/line/line.test.ts
@@ -334,8 +334,46 @@ describe('what a removed heading leaves behind', () => {
 
   test('a list item holding the section the heading held', () => {
     assert.deepEqual(removed(SECTIONED, SECTION), [
-      '- D', '  - E', '  \t- etc', '# Next', '- untouched',
+      '- D', '\t- E', '\t\t- etc', '# Next', '- untouched',
     ]);
+  });
+
+  /**
+   * The section moves as one block, and in the unit the document already uses.
+   * Padding a tab-indented list with spaces leaves `\t- child` written as
+   * `  \t- child` — two indent styles on one line, a child of its parent only
+   * because a tab happens to land on the column the parent's text starts at.
+   */
+  test('the block takes the indent the section already writes', () => {
+    const tabs = ['# D', '- E', '\t- F', '- G'];
+    const spaces = ['# D', '- E', '    - F', '- G'];
+
+    assert.deepEqual(removed(tabs, SECTION), ['- D', '\t- E', '\t\t- F', '\t- G']);
+    assert.deepEqual(removed(spaces, SECTION), ['- D', '    - E', '        - F', '    - G']);
+  });
+
+  test('the narrowest indent is the level, not the first one met', () => {
+    const lines = ['# D', '\t\t- deep first', '\t- one level'];
+
+    assert.deepEqual(removed(lines, SECTION), ['- D', '\t\t\t- deep first', '\t\t- one level']);
+  });
+
+  test('a flat section has no indent to learn from, so the marker sets it', () => {
+    assert.deepEqual(removed(['# D', '- E', 'body'], SECTION), ['- D', '  - E', '  body']);
+  });
+
+  test('every line moves by the same amount, so the section keeps its shape', () => {
+    const lines = ['# D', '- E', '\t- F', '\t\t- G', '- H'];
+    const before = lines.slice(1).map((line) => line.length - line.trimStart().length);
+    const after = removed(lines, SECTION).slice(1).map(
+      (line) => line.length - line.trimStart().length
+    );
+
+    assert.deepEqual(
+      after.map((width, index) => width - before[index]),
+      [1, 1, 1, 1],
+      'a uniform shift is what leaves the relative nesting untouched'
+    );
   });
 
   test('the section stops at the next heading, whatever its level', () => {

--- a/tests/editor/headingAdjustmentService.test.ts
+++ b/tests/editor/headingAdjustmentService.test.ts
@@ -1,6 +1,8 @@
 import { describe, test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
+const NO_CONVERSION = { headingsToBullets: false, bulletsToHeadings: false };
+
 import {
   adjustEditorHeadings,
   adjustEditorLine,
@@ -205,7 +207,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', 'some prose', '### C'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'child', 'sibling');
+    placeEditorLine(asEditor(editor), 'child', 'sibling', NO_CONVERSION);
 
     assert.equal(written(editor, before), '## A\n### some prose\n### C');
   });
@@ -214,7 +216,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', '#### B'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'plain', 'sibling');
+    placeEditorLine(asEditor(editor), 'plain', 'sibling', NO_CONVERSION);
 
     assert.equal(written(editor, before), '## A\nB');
   });
@@ -223,7 +225,7 @@ describe('a placement reads the cursor too', () => {
     const before = ['## A', '### B'];
     const editor = fakeEditor([...before], 1);
 
-    placeEditorLine(asEditor(editor), 'child', 'sibling');
+    placeEditorLine(asEditor(editor), 'child', 'sibling', NO_CONVERSION);
 
     assert.deepEqual(editor.transactions, []);
   });
@@ -242,7 +244,7 @@ describe('the caret after writing a heading onto the current line', () => {
   test('waits after the hash on an empty line, ready to be typed into', () => {
     const editor = fakeEditor(['## Setup', ''], 1, 0);
 
-    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling', NO_CONVERSION);
 
     assert.equal(written(editor, ['## Setup', '']), '## Setup\n## ');
     assert.deepEqual(caret(editor), { line: 1, ch: 3 });
@@ -251,7 +253,7 @@ describe('the caret after writing a heading onto the current line', () => {
   test('stays with its text on a line that has some', () => {
     const editor = fakeEditor(['## Setup', 'some prose'], 1, 5);
 
-    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling', NO_CONVERSION);
 
     // `some |prose` before, `## some |prose` after: the same character.
     assert.deepEqual(caret(editor), { line: 1, ch: 8 });
@@ -260,7 +262,7 @@ describe('the caret after writing a heading onto the current line', () => {
   test('is not pushed behind the markup when it sits at the head of the line', () => {
     const editor = fakeEditor(['## Setup', 'some prose'], 1, 0);
 
-    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling', NO_CONVERSION);
 
     assert.deepEqual(caret(editor), { line: 1, ch: 3 });
   });
@@ -268,7 +270,7 @@ describe('the caret after writing a heading onto the current line', () => {
   test('comes back with the text when the heading is taken off', () => {
     const editor = fakeEditor(['## Setup', '## some prose'], 1, 6);
 
-    placeEditorLine(asEditor(editor), 'toggle', 'sibling');
+    placeEditorLine(asEditor(editor), 'toggle', 'sibling', NO_CONVERSION);
 
     // `## som|e prose` before, `som|e prose` after.
     assert.equal(written(editor, ['## Setup', '## some prose']), '## Setup\nsome prose');

--- a/tests/settings/settings.test.ts
+++ b/tests/settings/settings.test.ts
@@ -18,6 +18,8 @@ describe('defaultLevelFor', () => {
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
       toggleTarget: 'sibling',
+      liftNestedOnHeading: true,
+      removeHeadingAs: 'plain',
       customRangeTop: 'note-start',
       customRangeBottom: 'note-end',
     };
@@ -36,6 +38,8 @@ describe('readSettings', () => {
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
       toggleTarget: 'sibling',
+      liftNestedOnHeading: true,
+      removeHeadingAs: 'plain',
       customRangeTop: 'note-start',
       customRangeBottom: 'note-end',
     });
@@ -56,6 +60,8 @@ describe('readSettings', () => {
       bulletsToHeadings: false,
       deepestHeadingLevel: 6,
       toggleTarget: 'sibling',
+      liftNestedOnHeading: true,
+      removeHeadingAs: 'plain',
       customRangeTop: 'note-start',
       customRangeBottom: 'note-end',
     });

--- a/tests/settings/settingsTab.test.ts
+++ b/tests/settings/settingsTab.test.ts
@@ -295,3 +295,57 @@ describe('the custom range boundaries', () => {
     assert.deepEqual(saves, []);
   });
 });
+
+describe('what a removed heading leaves', () => {
+  test('offers exactly the three things it can write', async () => {
+    const { tab } = tabFor(await defaults());
+    const control = controls(tab).find((each) => each.key === 'removeHeadingAs');
+
+    assert.ok(control && control.type === 'dropdown');
+    assert.deepEqual(Object.keys(control.options), ['plain', 'bullet', 'bullet-with-section']);
+  });
+
+  test('a fresh install writes plain text, which is what it always wrote', async () => {
+    assert.equal((await defaults()).removeHeadingAs, 'plain');
+  });
+
+  test('a chosen option is stored and persisted', async () => {
+    const settings = await defaults();
+    const { tab, saves } = tabFor(settings);
+
+    await tab.setControlValue('removeHeadingAs', 'bullet-with-section');
+
+    assert.equal(settings.removeHeadingAs, 'bullet-with-section');
+    assert.equal(saves.length, 1);
+  });
+
+  test('a string it does not offer is refused rather than stored', async () => {
+    const settings = await defaults();
+    const { tab, saves } = tabFor(settings);
+
+    await tab.setControlValue('removeHeadingAs', 'a numbered item');
+
+    assert.equal(settings.removeHeadingAs, 'plain');
+    assert.deepEqual(saves, [], 'nothing was written, so nothing is persisted');
+  });
+});
+
+describe('bringing nested list items along', () => {
+  /**
+   * On rather than off: a heading that strands its children at an indent
+   * nothing encloses is broken markup, not a preference.
+   */
+  test('a fresh install has it switched on', async () => {
+    assert.equal((await defaults()).liftNestedOnHeading, true);
+  });
+
+  test('switching it off is stored and persisted', async () => {
+    const settings = await defaults();
+    const { tab, saves } = tabFor(settings);
+
+    await tab.setControlValue('liftNestedOnHeading', false);
+
+    assert.equal(settings.liftNestedOnHeading, false);
+    assert.equal(saves.length, 1);
+  });
+});

--- a/tests/settings/settingsTab.test.ts
+++ b/tests/settings/settingsTab.test.ts
@@ -97,7 +97,7 @@ describe('getSettingDefinitions', () => {
 
     assert.deepEqual(
       groups.map((group) => ('heading' in group ? group.heading : undefined)),
-      ['Default shift', 'Custom range', 'Toggle heading on current line', 'Bullet conversion']
+      ['Default shift', 'Custom range', 'Placing a heading on the current line', 'Bullet conversion']
     );
   });
 


### PR DESCRIPTION
Closes #13.

A list item holds what is indented past it; a heading holds what follows it until the next heading. The two disagree about what sits underneath, so a line that stops being one and starts being the other left its content answering to nothing — a deeply nested item turned into a heading stranded its children at an indent CommonMark reads as a code block.

## Two settings, both on the placement commands

**Bring nested list items along** — on by default. When "Toggle heading", "Sibling of the heading above" or "Child of the heading above" turns a list item into a heading, the items nested under it move out by as much as the item lost:

```
- A                    - A
  - B                    - B
    - C                    - C
      - D    ← caret    # D
        - E              - E
          - etc            - etc
```

On rather than off because the markup it replaces is broken rather than merely unhelpful. It reads the first nested line's own indent instead of assuming a unit, so tab-, two- and four-space lists all land their children at column zero.

**Removing a heading leaves** — a dropdown, defaulting to what the command always wrote:

| Setting | `# D` followed by `- E` becomes |
| --- | --- |
| Plain text *(default)* | `D` / `- E` |
| A list item | `- D` / `- E` |
| A list item, with the section nested under it | `- D` / `  - E` |

A dropdown rather than two toggles: indenting the section means nothing unless a marker is written, so as separate flags one would silently do nothing half the time.

## Notes

Both settings live on `ConversionSettings` rather than `HeadingAdjusterSettings`, which is at the seven-member limit — and they are heading-to-list-item conversions like the two already there. The scan is a new leaf under `line/`, because `conversion/` is not reachable from there without breaking the one-parent rule.

A carried section moves as one block and in the unit the document already uses: the narrowest indent the section contains, taken verbatim. Padding a tab-nested list with spaces produced `  \t- child` — two indent styles on one line, holding together only because a tab lands on the column the parent's text starts at.

The round trip does not close on depth. A heading records nothing about how far the item it came from was indented, so a lifted item comes back at the top level — the same limit ADR-0001 describes.

## Tests

560 passing, up from 524. The two seams the change touched are mutation-checked: dropping the `conversion()` argument from `placeCurrentLine` fails two tests, and deleting the new `storeOption` branch fails one. One test pins the uniform-shift property, so a future change that starts reindenting line-by-line fails loudly.
